### PR TITLE
Revert "Remove LIBSASL_API to sasldb"

### DIFF
--- a/sasldb/sasldb.h
+++ b/sasldb/sasldb.h
@@ -73,7 +73,7 @@ int _sasldb_putdata(const sasl_utils_t *utils,
 		    const char *data, size_t data_len);
 
 /* Should be run before any db access is attempted */
-int _sasl_check_db(const sasl_utils_t *utils,
+LIBSASL_API int _sasl_check_db(const sasl_utils_t *utils,
 		   sasl_conn_t *conn);
 
 /* These allow iterating through the keys of the database */
@@ -84,15 +84,15 @@ typedef int (* sasldb_list_callback_t) (const char *authid,
 					const char *property,
 					void *rock);
 
-sasldb_handle _sasldb_getkeyhandle(const sasl_utils_t *utils,
+LIBSASL_API sasldb_handle _sasldb_getkeyhandle(const sasl_utils_t *utils,
 				   sasl_conn_t *conn);
-int _sasldb_getnextkey(const sasl_utils_t *utils,
+LIBSASL_API int _sasldb_getnextkey(const sasl_utils_t *utils,
 		       sasldb_handle handle, char *out,
 		       const size_t max_out, size_t *out_len);
-int _sasldb_releasekeyhandle(const sasl_utils_t *utils,
+LIBSASL_API int _sasldb_releasekeyhandle(const sasl_utils_t *utils,
 			     sasldb_handle handle);
 
-int _sasldb_listusers(const sasl_utils_t *utils,
+LIBSASL_API int _sasldb_listusers(const sasl_utils_t *utils,
 				  sasl_conn_t *context,
 				  sasldb_list_callback_t callback,
 				  void *callback_rock);


### PR DESCRIPTION
This reverts commit 1518b84c1a1adb1fce4c28da7bfce6bf69064016.

The patch broke the msvc builds using nmake
