### PR TITLE
New version of Enable PAM_RHOST patch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,53 @@
+2016-10-18  Ken Murchison <murch@andrew.cmu.edu>
+	* Fixed potential DoS attack on saslauthd/doors (from Oracle)
+
+2016-06-30  Ken Murchison <murch@andrew.cmu.edu>
+	* plugins/ntlm.c, otp.c: support OpenSSL 1.1
+
+2016-06-14  Ken Murchison <murch@andrew.cmu.edu>
+	* plugins/digestmd5.c: Fix memory leak in client step 2
+
+2016-03-24  Ken Murchison <murch@andrew.cmu.edu>
+	* auth_rimap.c: Don't hang when IMAP server closes connection
+
+2016-01-29  Ken Murchison <murch@andrew.cmu.edu>
+	* Build fixes from Ignacio Casal Quinteiro
+
+2015-12-26  Ken Murchison <murch@andrew.cmu.edu>
+	* Build fixes from Ignacio Casal Quinteiro
+
+2015-11-16  Ken Murchison <murch@andrew.cmu.edu>
+	* Build fixes from Ignacio Casal Quinteiro
+
+2015-10-14  Ken Murchison <murch@andrew.cmu.edu>
+	* Build fixes from Ignacio Casal Quinteiro
+
+2015-07-17  Ken Murchison <murch@andrew.cmu.edu>
+	* auth_krb5.c: added krb5_conv_krb4_instance option
+
+2014-11-17  Ken Murchison <murch@andrew.cmu.edu>
+	* plugins/digestmd5.c: Fix memory leaks
+
+2014-11-17  Ken Murchison <murch@andrew.cmu.edu>
+	* plugins/digestmd5.c: prevent going from step 3 to step 2
+
+2013-09-13  Alexey Melnikov <alexey.melnikov@isode.com>
+	* Fix memory leaks in DIGEST
+
+2013-08-30  Ken Murchison <murch@andrew.cmu.edu>
+	* plugins/digestmd5.c: only locate reauth cache when reauth is
+	  enabled
+
+2013-07-11  Alexey Melnikov <alexey.melnikov@isode.com>
+	* Treat SCRAM and DIGEST as more secure than PLAIN when selecting
+	  client-side mechanism
+
+2013-07-11  Alexey Melnikov <alexey.melnikov@isode.com>
+	* Handle NULL return from crypt()
+
+2012-11-20  Alexey Melnikov <alexey.melnikov@isode.com>
+	* Added support for lmdb
+
 2012-11-19  Alexey Melnikov <alexey.melnikov@isode.com>
 	* Final 2.1.26 tagged and released by Ken.
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,10 +49,10 @@ dnl REMINDER: When changing the version number here, please also update
 dnl the values in win32/include/config.h and include/sasl.h as well.
 dnl
 AC_INIT([cyrus-sasl],
-        [2.1.26],
-        [https://git.cyrus.foundation/maniphest/],
+        [2.1.27],
+        [https://github.com/cyrusimap/cyrus-sasl/issues],
         [cyrus-sasl],
-        [https://docs.cyrus.foundation])
+        [http://cyrusimap.org])
 
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/include/sasl.h
+++ b/include/sasl.h
@@ -126,7 +126,7 @@
 /* Keep in sync with win32/common.mak */
 #define SASL_VERSION_MAJOR 2
 #define SASL_VERSION_MINOR 1
-#define SASL_VERSION_STEP 26
+#define SASL_VERSION_STEP 27
 
 /* A convenience macro: same as was defined in the OpenLDAP LDAPDB */
 #define SASL_VERSION_FULL ((SASL_VERSION_MAJOR << 16) |\

--- a/lib/checkpw.c
+++ b/lib/checkpw.c
@@ -654,6 +654,8 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
     char pwpath[sizeof(srvaddr.sun_path)];
     const char *p = NULL;
     char *freeme = NULL;
+    char *freemetoo = NULL;
+    const char *client_addr = NULL;
 #ifdef USE_DOORS
     door_arg_t arg;
 #endif
@@ -686,13 +688,19 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 	user_realm = rtmp + 1;
     }
 
+    if (sasl_getprop(conn, SASL_IPREMOTEPORT, (const void **) & client_addr) == SASL_OK) {
+	if(_sasl_strdup(client_addr, &freemetoo, NULL) != SASL_OK)
+	    goto fail;
+	client_addr = freemetoo;
+    }
+
     /*
      * build request of the form:
      *
-     * count authid count password count service count realm
+     * count authid count password count service count realm client
      */
     {
- 	unsigned short max_len, req_len, u_len, p_len, s_len, r_len;
+	unsigned short max_len, req_len, u_len, p_len, s_len, r_len, c_len;
  
 	max_len = (unsigned short) sizeof(query);
 
@@ -700,7 +708,8 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 	if ((strlen(userid) > USHRT_MAX) ||
 	    (strlen(passwd) > USHRT_MAX) ||
 	    (strlen(service) > USHRT_MAX) ||
-	    (user_realm && (strlen(user_realm) > USHRT_MAX))) {
+	    (user_realm && (strlen(user_realm) > USHRT_MAX)) ||
+	    (client_addr && (strlen(client_addr) > USHRT_MAX))) {
 	    goto toobig;
 	}
 
@@ -708,6 +717,7 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
  	p_len = (strlen(passwd));
 	s_len = (strlen(service));
 	r_len = ((user_realm ? strlen(user_realm) : 0));
+	c_len = ((client_addr ? strlen(client_addr): 0));
 
 	/* prevent buffer overflow */
 	req_len = 30;
@@ -718,11 +728,14 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 	if (max_len - req_len < s_len) goto toobig;
 	req_len += s_len;
 	if (max_len - req_len < r_len) goto toobig;
+	req_len += r_len;
+	if (max_len - req_len < c_len) goto toobig;
 
 	u_len = htons(u_len);
 	p_len = htons(p_len);
 	s_len = htons(s_len);
 	r_len = htons(r_len);
+	c_len = htons(c_len);
 
 	memcpy(query_end, &u_len, sizeof(unsigned short));
 	query_end += sizeof(unsigned short);
@@ -739,6 +752,10 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 	memcpy(query_end, &r_len, sizeof(unsigned short));
 	query_end += sizeof(unsigned short);
 	if (user_realm) while (*user_realm) *query_end++ = *user_realm++;
+
+	memcpy(query_end, &c_len, sizeof(unsigned short));
+	query_end += sizeof(unsigned short);
+	if(client_addr) while (*client_addr) *query_end++ = *client_addr++;
     }
 
 #ifdef USE_DOORS
@@ -840,6 +857,7 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 #endif /* USE_DOORS */
   
     if(freeme) free(freeme);
+    if(freemetoo) free(freemetoo);
 
     if (!strncmp(response, "OK", 2)) {
 	return SASL_OK;
@@ -854,6 +872,7 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 
  fail:
     if (freeme) free(freeme);
+    if (freemetoo) free(freemetoo);
     return SASL_FAIL;
 }
 

--- a/saslauthd/auth_dce.c
+++ b/saslauthd/auth_dce.c
@@ -56,7 +56,8 @@ auth_dce(
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   /* END PARAMETERS */
   )
 {
@@ -104,7 +105,8 @@ auth_dce(
   const char *login __attribute__((unused)),
   const char *password __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
      return NULL;

--- a/saslauthd/auth_dce.h
+++ b/saslauthd/auth_dce.h
@@ -26,4 +26,4 @@
  * END COPYRIGHT
  */
 
-char *auth_dce(const char *, const char *, const char *, const char *);
+char *auth_dce(const char *, const char *, const char *, const char *, const char *);

--- a/saslauthd/auth_getpwent.c
+++ b/saslauthd/auth_getpwent.c
@@ -72,7 +72,8 @@ auth_getpwent (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))   /* I: remote host address */
   /* END PARAMETERS */
   )
 {

--- a/saslauthd/auth_getpwent.h
+++ b/saslauthd/auth_getpwent.h
@@ -25,4 +25,4 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_getpwent(const char *, const char *, const char *, const char *);
+char *auth_getpwent(const char *, const char *, const char *, const char *, const char *);

--- a/saslauthd/auth_httpform.c
+++ b/saslauthd/auth_httpform.c
@@ -488,7 +488,8 @@ auth_httpform (
   const char *user,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm                    /* I: user's realm */
+  const char *realm,                    /* I: user's realm */
+  const char *remote __attribute__((unused)) /* I: client address */
   /* END PARAMETERS */
   )
 {

--- a/saslauthd/auth_httpform.h
+++ b/saslauthd/auth_httpform.h
@@ -25,5 +25,5 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_httpform(const char *, const char *, const char *, const char *);
+char *auth_httpform(const char *, const char *, const char *, const char *, const char *);
 int auth_httpform_init(void);

--- a/saslauthd/auth_krb4.c
+++ b/saslauthd/auth_krb4.c
@@ -171,7 +171,8 @@ auth_krb4 (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service,
-  const char *realm_in
+  const char *realm_in,
+  const char *remote                    /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -282,7 +283,8 @@ auth_krb4 (
   const char *login __attribute__((unused)),
   const char *password __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
     return NULL;

--- a/saslauthd/auth_krb4.h
+++ b/saslauthd/auth_krb4.h
@@ -25,5 +25,5 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_krb4(const char *, const char *, const char *, const char *);
+char *auth_krb4(const char *, const char *, const char *, const char *, const char *);
 int auth_krb4_init(void);

--- a/saslauthd/auth_krb5.c
+++ b/saslauthd/auth_krb5.c
@@ -179,7 +179,8 @@ auth_krb5 (
   const char *user,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service,                  /* I: service authenticating to */
-  const char *realm                     /* I: user's realm */
+  const char *realm,                    /* I: user's realm */
+  const char *remote                    /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -365,7 +366,8 @@ auth_krb5 (
   const char *user,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service,			/* I: service authenticating to */
-  const char *realm			/* I: user's realm */
+  const char *realm,			/* I: user's realm */
+  const char *remote                    /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -473,7 +475,8 @@ auth_krb5 (
   const char *login __attribute__((unused)),
   const char *password __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
     return NULL;

--- a/saslauthd/auth_krb5.h
+++ b/saslauthd/auth_krb5.h
@@ -25,5 +25,5 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_krb5(const char *, const char *, const char *, const char *);
+char *auth_krb5(const char *, const char *, const char *, const char *, const char *);
 int auth_krb5_init(void);

--- a/saslauthd/auth_ldap.c
+++ b/saslauthd/auth_ldap.c
@@ -60,7 +60,8 @@ auth_ldap(
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service,
-  const char *realm
+  const char *realm,
+  const char *remote                    /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -110,7 +111,8 @@ auth_ldap(
   const char *login __attribute__((unused)),
   const char *password __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
      return NULL;

--- a/saslauthd/auth_ldap.h
+++ b/saslauthd/auth_ldap.h
@@ -25,5 +25,5 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_ldap(const char *, const char *, const char *, const char *);
+char *auth_ldap(const char *, const char *, const char *, const char *, const char *);
 int auth_ldap_init(void);

--- a/saslauthd/auth_pam.c
+++ b/saslauthd/auth_pam.c
@@ -186,7 +186,8 @@ auth_pam (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service,			/* I: service name */
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote                    /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -212,6 +213,14 @@ auth_pam (
     }
 
     my_appdata.pamh = pamh;
+
+    char * remote_host = strdup(remote);
+    if (remote_host) {
+	char * semicol = strchr(remote_host, ';');
+	if (semicol) * semicol = NULL; /* truncate remote_host at the ';' port separator */
+	pam_set_item(pamh, PAM_RHOST, remote_host);
+	free (remote_host);
+    }
 
     rc = pam_authenticate(pamh, PAM_SILENT);
     if (rc != PAM_SUCCESS) {
@@ -242,7 +251,8 @@ auth_pam(
   const char *login __attribute__((unused)),
   const char *password __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
     return NULL;

--- a/saslauthd/auth_pam.h
+++ b/saslauthd/auth_pam.h
@@ -32,4 +32,4 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_pam(const char *, const char *, const char *, const char *);
+char *auth_pam(const char *, const char *, const char *, const char *, const char *);

--- a/saslauthd/auth_rimap.c
+++ b/saslauthd/auth_rimap.c
@@ -309,7 +309,8 @@ auth_rimap (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused)) /* I: remote host address */
   /* END PARAMETERS */
   )
 {

--- a/saslauthd/auth_rimap.h
+++ b/saslauthd/auth_rimap.h
@@ -25,5 +25,5 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_rimap(const char *, const char *, const char *, const char *);
+char *auth_rimap(const char *, const char *, const char *, const char *, const char *);
 int auth_rimap_init(void);

--- a/saslauthd/auth_sasldb.c
+++ b/saslauthd/auth_sasldb.c
@@ -118,13 +118,14 @@ auth_sasldb (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm
+  const char *realm,
 #else
   const char *login __attribute__((unused)),/* I: plaintext authenticator */
   const char *password __attribute__((unused)),  /* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
 #endif
+  const char *remote __attribute__((unused)) /* I: remote host address */
   /* END PARAMETERS */
   )
 {

--- a/saslauthd/auth_sasldb.h
+++ b/saslauthd/auth_sasldb.h
@@ -25,4 +25,4 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_sasldb(const char *, const char *, const char *, const char *);
+char *auth_sasldb(const char *, const char *, const char *, const char *, const char *);

--- a/saslauthd/auth_shadow.c
+++ b/saslauthd/auth_shadow.c
@@ -95,7 +95,8 @@ auth_shadow (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused)) /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -315,7 +316,8 @@ auth_shadow (
   const char *login __attribute__((unused)),
   const char *passwd __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
     return NULL;

--- a/saslauthd/auth_shadow.h
+++ b/saslauthd/auth_shadow.h
@@ -25,4 +25,4 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_shadow(const char *, const char *, const char *, const char *);
+char *auth_shadow(const char *, const char *, const char *, const char *, const char *);

--- a/saslauthd/auth_sia.c
+++ b/saslauthd/auth_sia.c
@@ -56,7 +56,8 @@ auth_sia (
   const char *login,			/* I: plaintext authenticator */
   const char *password,			/* I: plaintext password */
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused)) /* I: remote host address */
   /* END PARAMETERS */
   )
 {
@@ -84,7 +85,8 @@ auth_sia(
   const char *login __attribute__((unused)),
   const char *password __attribute__((unused)),
   const char *service __attribute__((unused)),
-  const char *realm __attribute__((unused))
+  const char *realm __attribute__((unused)),
+  const char *remote __attribute__((unused))
   )
 {
     return NULL;

--- a/saslauthd/auth_sia.h
+++ b/saslauthd/auth_sia.h
@@ -25,4 +25,4 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-char *auth_sia(const char *, const char *, const char *, const char *);
+char *auth_sia(const char *, const char *, const char *, const char *, const char *);

--- a/saslauthd/ipc_doors.c
+++ b/saslauthd/ipc_doors.c
@@ -203,13 +203,42 @@ void ipc_cleanup() {
 		logger(L_DEBUG, L_FUNC, "door file removed: %s", door_file);
 }
 
+/*************************************************************
+ * It is very rare but not impossible to have door_return actually return.
+ * When it does, it leaks a reference count.  Prevent that.
+ **************************************************************/
+
+void
+safe_door_return(char *data, size_t len)
+{
+    (void) door_return(data, len, NULL, 0);
+    /*
+     * If door_return() failed, and our response wasn't empty, try sending
+     * an empty response.  If that still doesn't work, then we must exit
+     * this thread.
+     */
+    if (len > 0) {
+	logger(L_ERR, L_FUNC, "door_return: %s", strerror(errno));
+	(void) door_return(NULL, 0, NULL, 0);
+    }
+    logger(L_ERR, L_FUNC, "door_return: %s", strerror(errno));
+
+    pthread_mutex_lock(&num_lock);
+    if (num_procs > 0 && num_thr > 0) {
+	num_thr--;
+    }
+    pthread_mutex_unlock(&num_lock);
+    pthread_exit(NULL);
+}
+
 
 /*************************************************************
  * Handle the door data, pass the request off to
  * do_auth() back in saslauthd-main.c, then send the 
  * result back through the door.
  **************************************************************/
-void do_request(void *cookie, char *data, size_t datasize, door_desc_t *dp, size_t ndesc) {
+static void
+do_request(void *cookie, char *data, size_t datasize, door_desc_t *dp, uint_t ndesc) {
 	unsigned short		count = 0;                 /* input/output data byte count           */
 	char			*response = NULL;          /* response to send to the client         */
 	char			response_buff[1024];       /* temporary response buffer              */
@@ -226,6 +255,12 @@ void do_request(void *cookie, char *data, size_t datasize, door_desc_t *dp, size
 	 * authenticate them.
 	 **************************************************************/
 	dataend = data + datasize;
+
+	if (data == NULL || datasize < sizeof(unsigned short)) {
+		logger(L_ERR, L_FUNC, "Bad data");
+		send_no("");
+		return;
+	}
 
 	/* login id */
 	memcpy(&count, data, sizeof(unsigned short));
@@ -328,8 +363,7 @@ void do_request(void *cookie, char *data, size_t datasize, door_desc_t *dp, size
 	if (flags & VERBOSE)
 	    logger(L_DEBUG, L_FUNC, "response: %s", response_buff);
 
-	if(door_return(response_buff, strlen(response_buff), NULL, 0) < 0)
-	    logger(L_ERR, L_FUNC, "door_return: %s", strerror(errno));
+	safe_door_return(response_buff, strlen(response_buff));
 
 	return;
 }
@@ -353,14 +387,17 @@ void need_thread(door_info_t *di) {
 
     pthread_create(&newt, &thread_attr, &server_thread, NULL);
 }
- 
+
 /*************************************************************
  * Start a new server thread.
  * Make it available for door invocations.
  **************************************************************/
 void *server_thread(void *arg) {
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-    door_return(NULL, 0, NULL, 0);
+
+    safe_door_return(NULL, 0);
+
+    return (void *) NULL;
 }
 
 /*************************************************************
@@ -382,8 +419,7 @@ void send_no(char *mesg) {
 	if (flags & VERBOSE)
 	    logger(L_DEBUG, L_FUNC, "response: %s", buff);
 
-	if(door_return(buff, strlen(buff), NULL, 0) < 0)
-	    logger(L_ERR, L_FUNC, "door_return: %s", strerror(errno));
+	safe_door_return(buff, strlen(buff));
 
 	return;	
 }

--- a/saslauthd/mechanisms.h
+++ b/saslauthd/mechanisms.h
@@ -40,8 +40,8 @@ typedef struct {
     char *name;				/* name of the mechanism */
     int (*initialize)(void);		/* initialization function */
     char *(*authenticate)(const char *, const char *,
-			  const char *, const char *); /* authentication
-							  function */
+			  const char *, const char *,
+			  const char *); /* authentication function */
 } authmech_t;
 
 extern authmech_t mechanisms[];		/* array of supported auth mechs */

--- a/saslauthd/saslauthd-main.c
+++ b/saslauthd/saslauthd-main.c
@@ -378,7 +378,7 @@ int main(int argc, char **argv) {
  * return a pointer to a string to send back to the client.
  * The caller is responsible for freeing the pointer. 
  **************************************************************/
-char *do_auth(const char *_login, const char *password, const char *service, const char *realm) {
+char *do_auth(const char *_login, const char *password, const char *service, const char *realm, const char *remote) {
 
 	struct cache_result	lkup_result;
 	char			*response;
@@ -407,7 +407,7 @@ char *do_auth(const char *_login, const char *password, const char *service, con
 		response = strdup("OK");
 		cached = 1;
 	} else {
-		response = auth_mech->authenticate(login, password, service, realm);
+		response = auth_mech->authenticate(login, password, service, realm, remote);
 
 		if (response == NULL) {
 			logger(L_ERR, L_FUNC, "internal mechanism failure: %s", auth_mech->name);
@@ -420,18 +420,18 @@ char *do_auth(const char *_login, const char *password, const char *service, con
 
 		if (flags & VERBOSE) {
 			if (cached) 
-				logger(L_DEBUG, L_FUNC, "auth success (cached): [user=%s] [service=%s] [realm=%s]", \
-					login, service, realm);
+				logger(L_DEBUG, L_FUNC, "auth success (cached): [user=%s] [service=%s] [realm=%s] [remote=%s]", \
+					login, service, realm, remote);
 			else
-				logger(L_DEBUG, L_FUNC, "auth success: [user=%s] [service=%s] [realm=%s] [mech=%s]", \
-					login, service, realm, auth_mech->name);
+				logger(L_DEBUG, L_FUNC, "auth success: [user=%s] [service=%s] [realm=%s] [remote=%s] [mech=%s]", \
+					login, service, realm, remote, auth_mech->name);
 		}
 		return response;
 	}
 
 	if (strncmp(response, "NO", 2) == 0) {
-		logger(L_INFO, L_FUNC, "auth failure: [user=%s] [service=%s] [realm=%s] [mech=%s] [reason=%s]", \
-			login, service, realm, auth_mech->name,
+		logger(L_INFO, L_FUNC, "auth failure: [user=%s] [service=%s] [realm=%s] [remote=%s] [mech=%s] [reason=%s]", \
+			login, service, realm, remote, auth_mech->name,
 		        strlen(response) >= 4 ? response+3 : "Unknown");
 
 		return response;

--- a/saslauthd/saslauthd-main.h
+++ b/saslauthd/saslauthd-main.h
@@ -89,7 +89,8 @@
 
 /* saslauthd-main.c */
 extern char	*do_auth(const char *, const char *,
-			 const char *, const char *);
+			 const char *, const char *,
+			 const char *);
 extern void	set_auth_mech(const char *);
 extern void	set_max_procs(const char *);
 extern void	set_mech_option(const char *);

--- a/saslauthd/testsaslauthd.c
+++ b/saslauthd/testsaslauthd.c
@@ -96,7 +96,8 @@ static int saslauthd_verify_password(const char *saslauthd_path,
 				   const char *userid, 
 				   const char *passwd,
 				   const char *service,
-				   const char *user_realm)
+				   const char *user_realm,
+				   const char *client_addr)
 {
     char response[1024];
     char query[8192];
@@ -130,12 +131,13 @@ static int saslauthd_verify_password(const char *saslauthd_path,
      * count authid count password count service count realm
      */
     {
- 	unsigned short u_len, p_len, s_len, r_len;
+	unsigned short u_len, p_len, s_len, r_len, c_len;
  
  	u_len = htons(strlen(userid));
  	p_len = htons(strlen(passwd));
 	s_len = htons(strlen(service));
 	r_len = htons((user_realm ? strlen(user_realm) : 0));
+	c_len = htons(((client_addr ? strlen(client_addr): 0)));
 
 	memcpy(query_end, &u_len, sizeof(unsigned short));
 	query_end += sizeof(unsigned short);
@@ -152,6 +154,10 @@ static int saslauthd_verify_password(const char *saslauthd_path,
 	memcpy(query_end, &r_len, sizeof(unsigned short));
 	query_end += sizeof(unsigned short);
 	if (user_realm) while (*user_realm) *query_end++ = *user_realm++;
+
+	memcpy(query_end, &c_len, sizeof(unsigned short));
+	query_end += sizeof(unsigned short);
+	if (client_addr) while (*client_addr) *query_end++ = *client_addr++;
     }
 
 #ifdef USE_DOORS
@@ -248,13 +254,17 @@ main(int argc, char *argv[])
 {
   const char *user = NULL, *password = NULL;
   const char *realm = NULL, *service = NULL, *path = NULL;
+  const char *client_addr = NULL;
   int c;
   int flag_error = 0;
   int result = 0;
   int repeat = 0;
 
-  while ((c = getopt(argc, argv, "p:u:r:s:f:R:")) != EOF)
+  while ((c = getopt(argc, argv, "p:u:r:s:f:R:a:")) != EOF)
       switch (c) {
+      case 'a':
+	  client_addr = optarg;
+	  break;
       case 'R':
 	  repeat = atoi(optarg);
 	  break;
@@ -284,7 +294,7 @@ main(int argc, char *argv[])
   if (flag_error) {
     (void)fprintf(stderr,
 		  "%s: usage: %s -u username -p password\n"
-		  "              [-r realm] [-s servicename]\n"
+		  "              [-r realm] [-s servicename] [-a clientaddr]\n"
 		  "              [-f socket path] [-R repeatnum]\n",
 		  argv[0], argv[0]);
     exit(1);
@@ -294,7 +304,7 @@ main(int argc, char *argv[])
   for (c = 0; c < repeat; c++) {
       /* saslauthd-authenticated login */
       printf("%d: ", c);
-      result = saslauthd_verify_password(path, user, password, service, realm);
+      result = saslauthd_verify_password(path, user, password, service, realm, client_addr);
   }
   return result;
 }

--- a/win32/common.mak
+++ b/win32/common.mak
@@ -2,7 +2,7 @@
 #Keep in sync with include/sasl.h and win32/include/config.h
 SASL_VERSION_MAJOR=2
 SASL_VERSION_MINOR=1
-SASL_VERSION_STEP=26
+SASL_VERSION_STEP=27
 
 !IF "$(STATIC)" == ""
 STATIC=yes

--- a/win32/include/config.h
+++ b/win32/include/config.h
@@ -55,7 +55,7 @@
 #define PACKAGE "cyrus-sasl"
 
 /* Our version */
-#define VERSION "2.1.26"
+#define VERSION "2.1.27"
 
 /* Visual Studio supports prototypes */
 #define PROTOTYPES     1


### PR DESCRIPTION
Originally submitted as

```
https://bugzilla.cyrusimap.org/show_bug.cgi?id=3468
```

The patch changes saslauthd's protocol ABI, I think this should lead to an increase in SONAME's ABI_VERSION field.

Contrary to what I said in the original bugzilla submission, the patch have been in production use since 5 years, on some of the systems I'm managing, in particular, on a frontend system getting more than 100 thousand login attempts each day, which makes for more than 200 million SASL login operations till now.

The protocol as implemented in testsaslauthd has been updated too, this solves
the issue Petr Lautrbach wrote about in

```
https://bugzilla.redhat.com/show_bug.cgi?id=683797#c12
```

While the changes are really limited, I'm hereby expressly authorizing
redistribution and use under the original file's license.

In detail:
1. lib/checkpw.c: 4 clause bsd-like license  *cmu 
2. saslauthd/auth_dce.{c,h}: 2 clause bsd-like license - *md
3. saslauthd/auth_getpwent.{c,h}: 2 clause bsd-like license - *md
4. saslauthd/auth_httpform.{c,h}: 2 clause bsd-like license - *pe
5. saslauthd/auth_krb4.{c,h}: 2 clause bsd-like license - *md
6. saslauthd/auth_krb5.{c,h}: 2 clause bsd-like license - *md
7. saslauthd/auth_ldap.{c,h}: 2 clause bsd-like license - *ib
8. saslauthd/auth_pam.{c,h}: 2 clause bsd-like license - *fk
9. saslauthd/auth_rimap.{c,h}: 2 clause bsd-like license - *md
10. saslauthd/auth_sasldb.{c,h}: 2 clause bsd-like license - *md
11. saslauthd/auth_shadow.{c,h}: 2 clause bsd-like license - *md
12. saslauthd/auth_sia.{c,h}: 2 clause bsd-like license - *md
13. saslauthd/ipc_doors.c: 2 clause bsd-like license - *md
14. saslauthd/ipc_unix.c: 2 clause bsd-like license - *md
15. saslauthd/mechanisms.h: 2 clause bsd-like license - *md
16. saslauthd/saslauthd-main.{c,h}: 2 clause bsd-like license - *md

*cmu - Carnegie Mellon University.
*md  - Messaging Direct Ltd.
*pe  - Pyx Engineering AG
*ib  - Igor Brezac
*fk  - Fabian Knittel

As for the copyright, I would be equally satisfied, at sasl project's
representative's sole option, either if it would be assigned to the respective
file's copyright owner, or if a statement was added in each of the modified .c
files declaring my own copyright on the changed portions.
