### PR TITLE
Add OpenSSL 1.1.0 support in saslauthd

### DIFF
--- a/plugins/ntlm.c
+++ b/plugins/ntlm.c
@@ -424,8 +424,8 @@ static HMAC_CTX *_plug_HMAC_CTX_new(const sasl_utils_t *utils)
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
     return HMAC_CTX_new();
 #else
-    return utils->malloc(sizeof(EVP_MD_CTX));
-#endif    
+    return utils->malloc(sizeof(HMAC_CTX));
+#endif
 }
 
 static void _plug_HMAC_CTX_free(HMAC_CTX *ctx, const sasl_utils_t *utils)
@@ -437,7 +437,7 @@ static void _plug_HMAC_CTX_free(HMAC_CTX *ctx, const sasl_utils_t *utils)
 #else
     HMAC_cleanup(ctx);
     utils->free(ctx);
-#endif    
+#endif
 }
 
 static unsigned char *V2(unsigned char *V2, sasl_secret_t *passwd,

--- a/plugins/otp.c
+++ b/plugins/otp.c
@@ -104,7 +104,7 @@ static EVP_MD_CTX *_plug_EVP_MD_CTX_new(const sasl_utils_t *utils)
     return EVP_MD_CTX_new();
 #else
     return utils->malloc(sizeof(EVP_MD_CTX));
-#endif    
+#endif
 }
 
 static void _plug_EVP_MD_CTX_free(EVP_MD_CTX *ctx, const sasl_utils_t *utils)
@@ -115,7 +115,7 @@ static void _plug_EVP_MD_CTX_free(EVP_MD_CTX *ctx, const sasl_utils_t *utils)
     EVP_MD_CTX_free(ctx);
 #else
     utils->free(ctx);
-#endif    
+#endif
 }
 
 /* Convert the binary data into ASCII hex */
@@ -180,13 +180,13 @@ static int generate_otp(const sasl_utils_t *utils,
 			"OTP algorithm %s is not available", alg->evp_name);
 	return SASL_FAIL;
     }
-    
+
     if ((mdctx = _plug_EVP_MD_CTX_new(utils)) == NULL) {
 	SETERROR(utils, "cannot allocate MD CTX");
 	r = SASL_NOMEM;
         goto done;
     }
-    
+
     if ((key = utils->malloc(strlen(seed) + secret_len + 1)) == NULL) {
 	SETERROR(utils, "cannot allocate OTP key");
 	r = SASL_NOMEM;
@@ -201,10 +201,10 @@ static int generate_otp(const sasl_utils_t *utils,
     while (seq-- > 0)
         otp_hash(md, (char *) otp, OTP_HASH_SIZE, otp, alg->swab, mdctx);
 
-  done:
+done:
     if (key) utils->free(key);
     if (mdctx) _plug_EVP_MD_CTX_free(mdctx, utils);
-    
+
     return r;
 }
 

--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -61,6 +61,35 @@
 #include <sasl.h>
 #include "lak.h"
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static EVP_MD_CTX *EVP_MD_CTX_new(void)
+{
+	return EVP_MD_CTX_create();
+}
+static void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{
+	if (ctx == NULL)
+		return;
+
+	EVP_MD_CTX_destroy(ctx);
+}
+
+static EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void)
+{
+	EVP_ENCODE_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+
+	if (ctx != NULL) {
+		memset(ctx, 0, sizeof(*ctx));
+	}
+	return ctx;
+}
+static void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx)
+{
+	OPENSSL_free(ctx);
+	return;
+}
+#endif
+
 typedef struct lak_auth_method {
 	int method;
 	int (*check) (LAK *lak, const char *user, const char *service, const char *realm, const char *password) ;
@@ -1720,20 +1749,28 @@ static int lak_base64_decode(
 
 	int rc, i, tlen = 0;
 	char *text;
-	EVP_ENCODE_CTX EVP_ctx;
+	EVP_ENCODE_CTX *enc_ctx = EVP_ENCODE_CTX_new();
 
-	text = (char *)malloc(((strlen(src)+3)/4 * 3) + 1);
-	if (text == NULL)
+	if (enc_ctx == NULL)
 		return LAK_NOMEM;
 
-	EVP_DecodeInit(&EVP_ctx);
-	rc = EVP_DecodeUpdate(&EVP_ctx, (unsigned char *) text, &i, (const unsigned char *)src, strlen(src));
+	text = (char *)malloc(((strlen(src)+3)/4 * 3) + 1);
+	if (text == NULL) {
+		EVP_ENCODE_CTX_free(enc_ctx);
+		return LAK_NOMEM;
+	}
+
+	EVP_DecodeInit(enc_ctx);
+	rc = EVP_DecodeUpdate(enc_ctx, (unsigned char *) text, &i, (const unsigned char *)src, strlen(src));
 	if (rc < 0) {
+		EVP_ENCODE_CTX_free(enc_ctx);
 		free(text);
 		return LAK_FAIL;
 	}
 	tlen += i;
-	EVP_DecodeFinal(&EVP_ctx, (unsigned char *) text, &i);
+	EVP_DecodeFinal(enc_ctx, (unsigned char *) text, &i);
+
+	EVP_ENCODE_CTX_free(enc_ctx);
 
 	*ret = text;
 	if (rlen != NULL)
@@ -1749,7 +1786,7 @@ static int lak_check_hashed(
 {
 	int rc, clen;
 	LAK_HASH_ROCK *hrock = (LAK_HASH_ROCK *) rock;
-	EVP_MD_CTX mdctx;
+	EVP_MD_CTX *mdctx;
 	const EVP_MD *md;
 	unsigned char digest[EVP_MAX_MD_SIZE];
 	char *cred;
@@ -1758,17 +1795,24 @@ static int lak_check_hashed(
 	if (!md)
 		return LAK_FAIL;
 
-	rc = lak_base64_decode(hash, &cred, &clen);
-	if (rc != LAK_OK)
-		return rc;
+	mdctx = EVP_MD_CTX_new();
+	if (!mdctx)
+		return LAK_NOMEM;
 
-	EVP_DigestInit(&mdctx, md);
-	EVP_DigestUpdate(&mdctx, passwd, strlen(passwd));
+	rc = lak_base64_decode(hash, &cred, &clen);
+	if (rc != LAK_OK) {
+		EVP_MD_CTX_free(mdctx);
+		return rc;
+	}
+
+	EVP_DigestInit(mdctx, md);
+	EVP_DigestUpdate(mdctx, passwd, strlen(passwd));
 	if (hrock->salted) {
-		EVP_DigestUpdate(&mdctx, &cred[EVP_MD_size(md)],
+		EVP_DigestUpdate(mdctx, &cred[EVP_MD_size(md)],
 				 clen - EVP_MD_size(md));
 	}
-	EVP_DigestFinal(&mdctx, digest, NULL);
+	EVP_DigestFinal(mdctx, digest, NULL);
+	EVP_MD_CTX_free(mdctx);
 
 	rc = memcmp((char *)cred, (char *)digest, EVP_MD_size(md));
 	free(cred);


### PR DESCRIPTION
Missing bits from OpenSSL compatibility:
 * copy/paste error in `ntlm.c` (and some whitespace cleanup)
 * `saslauthd` should use the new API too

Author: Tomas Mraz