### PR TITLE
document error in install.html

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -19,7 +19,7 @@ This document offers a general overview of installing the SASL library.
 </pre>
 
 <p>If you're checking this directly out of GIT, you'll need to run "sh
-./SMakefile" to build the configure script first.
+./autogen.sh" to build the configure script first.
 
 <p>Read <A HREF="sysadmin.html">the System Administrator's Guide</A> to
 learn how to configure libsasl in depth.  There is also a <A


### PR DESCRIPTION
Minor errors in install.html.
Currently 'sh ./autogen.sh' should be run to generate necessary configuration files.