### PR TITLE
Remove bogus <> to build the package

### DIFF
--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -1456,7 +1456,7 @@ static int lak_auth_bind(
 	  {
 		/* restore config bind */
                 lak_unbind(lak);
-		rc = lak_user(<>
+		rc = lak_user(
 		lak->conf->bind_dn,
 		lak->conf->id,
 		lak->conf->authz_id,


### PR DESCRIPTION
Resolve the syntax error introduced by #428 (this change makes it build for me).
The bogus characters are not part of the original patch on launchpad [1].

[1] https://bugs.launchpad.net/ubuntu/+source/cyrus-sasl2/+bug/1188475/comments/1