### PR TITLE
add a ldapsimple pwcheck plugin

### DIFF
--- a/plugins/makeinit.sh
+++ b/plugins/makeinit.sh
@@ -47,7 +47,7 @@ SASL_SERVER_PLUG_INIT( $mech )
 done
 
 # auxprop plugins
-for auxprop in sasldb sql ldapdb; do
+for auxprop in sasldb sql ldapdb ldapsimple; do
 
 echo "
 #include <config.h>
@@ -91,3 +91,4 @@ done
 
 # ldapdb is also a canon_user plugin
 echo "SASL_CANONUSER_PLUG_INIT( ldapdb )" >> ldapdb_init.c
+echo "SASL_CANONUSER_PLUG_INIT( ldapsimple )" >> ldapsimple_init.c

--- a/win32/common.mak
+++ b/win32/common.mak
@@ -26,7 +26,7 @@ LINK32EXE=$(LINK32)
 # It seems that -lib must be the first parameter
 LINK32LIB=link.exe /lib /nologo
 
-SYS_LIBS=ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib
+SYS_LIBS=ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib wldap32.lib
 
 !IF "$(BITS)" == "64"
 SYS_LIBS=$(SYS_LIBS) bufferoverflowU.lib

--- a/win32/include/config.h
+++ b/win32/include/config.h
@@ -117,7 +117,9 @@ typedef int		    intptr_t;
 /* Windows calls these functions something else
  */
 #define strcasecmp   stricmp
+#if _MSC_VER < 1900
 #define snprintf    _snprintf
+#endif
 #define strncasecmp  strnicmp
 
 #define MAXHOSTNAMELEN 1024


### PR DESCRIPTION

this mainly intend to be used under windows without permission to config
ldap server . for example setting up a svnserve on windows, but don't have
 admin account for domain controller. no config needs to be done on ldap server side,
but have following limitations:

all user must under same DN
user DN must be written in config
not support admin bind-search then bind process

sample config:
pwcheck_method: ldapsimple
mech_list: PLAIN
ldapsimple_servers:  ldap.forumsys.com
ldapsimple_dn: cn=%u,dc=example,dc=com
ldapsimple_port:389


currently this prototype only written and tested on windows, on other system you can use saslauthd to support full ldap authorization.