### PR TITLE
Make http_digest_client consistent with the other samples

### DIFF
--- a/sample/http_digest_client.c
+++ b/sample/http_digest_client.c
@@ -18,8 +18,8 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
-#include <sasl/sasl.h>
-   
+#include <sasl.h>
+
 #define SUCCESS 0
 #define ERROR   1
 


### PR DESCRIPTION
`#include <sasl/sasl.h>` requires that cyrus-sasl headers already be
installed on the system for the build to succeed; `#include <sasl.h>`
will instead pick up the copy present in the source tree.