### PR TITLE
Allow GSSAPI to work with no auxprop plugins

### DIFF
--- a/include/sasl.h
+++ b/include/sasl.h
@@ -640,8 +640,7 @@ typedef int sasl_server_userdb_setpass_t(sasl_conn_t *conn,
 #define SASL_CU_AUTHZID 0x02
 
 /* Combine the following with SASL_CU_AUTHID, if you don't want
-   to fail if auxprop returned SASL_NOUSER/SASL_NOMECH.
-   This flag has no effect on SASL_CU_AUTHZID. */
+   to fail if auxprop returned SASL_NOUSER/SASL_NOMECH. */
 #define SASL_CU_EXTERNALLY_VERIFIED 0x04
 
 #define SASL_CU_OVERRIDE	    0x08    /* mapped to SASL_AUXPROP_OVERRIDE */

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1360,8 +1360,9 @@ gssapi_server_mech_ssfreq(context_t *text,
 	ret = params->canon_user(params->utils->conn,
 				 ((char *) output_token->value) + 4,
 				 (output_token->length - 4) * sizeof(char),
-				 SASL_CU_AUTHZID, oparams);
-	
+				 SASL_CU_AUTHZID | SASL_CU_EXTERNALLY_VERIFIED,
+				 oparams);
+
 	if (ret != SASL_OK) {
 	    sasl_gss_free_context_contents(text);
 	    return ret;


### PR DESCRIPTION
I'm working on moving from an old set of servers running a custom build of Cyrus SASL 2.1.25 to shiny new RHEL 7 servers, and ran into a weird issue with a minimal install.

Without this patch, if there are no installed auxprop plugins GSSAPI authentication makes it through the first 3 steps, then logs "could not find auxprop plugin, was searching for '[all]'" and returns SASL_NOMECH to our application.

a321326ae4d5d79d053926167f76fdad52ec627b made `_sasl_auxprop_lookup()` return SASL_NOMECH when no auxprop plugins are found. 8ab8270447101c5d4262e82b765f8646cf5b989f attempted to fix the GSSAPI plugin, but only modified two of the three calls to `canon_user()` to use SASL_CU_EXTERNALLY_VERIFIED.