### PR TITLE
saslauthd: auth_krb5 rewrite

### DIFF
--- a/saslauthd/auth_krb5.c
+++ b/saslauthd/auth_krb5.c
@@ -31,7 +31,6 @@
 #include "mechanisms.h"
 #include "globals.h" /* mech_option */
 #include "cfile.h"
-#include "krbtf.h"
 
 #ifdef AUTH_KRB5
 # include <krb5.h>
@@ -61,11 +60,6 @@ auth_krb5_init (
 {
 #ifdef AUTH_KRB5
     char *configname = 0;
-
-    if (krbtf_init() == -1) {
-	syslog(LOG_ERR, "auth_krb5_init krbtf_init failed");
-	return -1;
-    }
 
     if (mech_option)
 	configname = mech_option;

--- a/saslauthd/auth_krb5.c
+++ b/saslauthd/auth_krb5.c
@@ -27,14 +27,6 @@
  * DAMAGE.
  * END COPYRIGHT */
 
-/* ok, this is  wrong but the most convenient way of doing 
- * it for now. We assume (possibly incorrectly) that if GSSAPI exists then 
- * the Kerberos 5 headers and libraries exist.   
- * What really should be done is a configure.in check for krb5.h and use 
- * that since none of this code is GSSAPI but rather raw Kerberos5.
- */
-
-
 /* PUBLIC DEPENDENCIES */
 #include "mechanisms.h"
 #include "globals.h" /* mech_option */


### PR DESCRIPTION
I went down a bit of a rabbit hole with this one.

7c779a14f48d0efe51378516c82a0d6da3fa43da is a patch that we've had deployed at UMich for ages. It adds support for specifying an explicit server name in saslauthd's configuration, which simplifies deployment in cases where it's difficult for the server to automatically determine which principal it should use. One example is an EC2 instance: the IP resolves to a random Amazon hostname and the instance itself usually thinks it's something like ip-172-31-31-254.us-west-2.compute.internal.

Our patch only touched the MIT implementation, so I thought it would be nice to add the same functionality to the Heimdal code before upstreaming...which turned out to be possible, but significantly changed the Heimdal implementation of `auth_krb5()`...to the point where it looked plausible that the same code would work under MIT. Which it does.

I've tested this against the following versions of the support libraries:
* MIT Kerberos 1.15.1 from RHEL (works)
* MIT Kerberos 1.10.3 from RHEL (works)
* Heimdal 1.6.0 from EPEL (works)
* Manual build of https://github.com/heimdal/heimdal/commit/2dc947105ad5342275b15f11e71a1eb4b80b99ab (heimdal-1-3-branch, works)
* Manual build of https://github.com/heimdal/heimdal/commit/04a118006fb9062cc0de8604e5549767668603a6 (heimdal-1-2-branch, fails due to missing `krb5_free_error_message()`)