### PR TITLE
configure.ac (issue #476): Fix configure warnings.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,7 +244,7 @@ AC_CHECK_PROGS(NM, nm)
 
 AC_MSG_CHECKING(for underscore before symbols)
 AC_CACHE_VAL(sasl_cv_uscore,[
-    echo "void main(){int i=1;}
+    echo "int main(){int i=1; return 0;}
     void foo(){int i=6;}" > conftest.c
     ${CC} -o a.out conftest.c > /dev/null
     if (${NM} a.out | grep _foo) > /dev/null; then
@@ -264,7 +264,7 @@ if test $sasl_cv_uscore = yes; then
 #include <dlfcn.h>
 #include <stdio.h>
 void foo() { int i=0;}
-void main() { void *self, *ptr1, *ptr2; self=dlopen(NULL,RTLD_LAZY);
+int main() { void *self, *ptr1, *ptr2; self=dlopen(NULL,RTLD_LAZY);
     if(self) { ptr1=dlsym(self,"foo"); ptr2=dlsym(self,"_foo");
     if(ptr1 && !ptr2) exit(0); } exit(1); } 
 ], [sasl_cv_dlsym_adds_uscore=yes], sasl_cv_dlsym_adds_uscore=no
@@ -499,8 +499,7 @@ if test "$otp" != no; then
   fi
 
   dnl Test for OPIE
-  AC_ARG_WITH(with-opie,[  --with-opie=PATH        use OPIE (One Time Passwords in Everything) from PATH],
-	with_opie="${withval}")
+  AC_ARG_WITH(opie, AC_HELP_STRING([--with-opie=PATH], [use OPIE (One Time Passwords in Everything) from PATH]))
 
   case "$with_opie" in
 	""|yes) 


### PR DESCRIPTION
Fix HP's aCC warning about wrong return type for main().
Fix warning about unrecognized option --without-opie.
Thanks dilyanpalauzov for the fixes!