### PR TITLE
When reporting errors, provide even more details.

### DIFF
--- a/include/saslplug.h
+++ b/include/saslplug.h
@@ -127,10 +127,10 @@ typedef struct sasl_utils {
      *
      * level is a SASL_LOG_* level (see sasl.h)
      */
-    void (*log)(sasl_conn_t *conn, int level, const char *fmt, ...);
+    void (*log)(sasl_conn_t *conn, int level, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 
     /* callback to sasl_seterror() */
-    void (*seterror)(sasl_conn_t *conn, unsigned flags, const char *fmt, ...);
+    void (*seterror)(sasl_conn_t *conn, unsigned flags, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 
     /* spare function pointer */
     int *(*spare_fptr)(void);
@@ -485,7 +485,7 @@ LIBSASL_API int sasl_client_plugin_info (const char *mech_list,
  ********************/
 
 /* log message formatting routine */
-typedef void sasl_logmsg_p(sasl_conn_t *conn, const char *fmt, ...);
+typedef void sasl_logmsg_p(sasl_conn_t *conn, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
 /*
  * input parameters to server SASL plugin

--- a/sasldb/db_ndbm.c
+++ b/sasldb/db_ndbm.c
@@ -112,8 +112,8 @@ int _sasldb_getdata(const sasl_utils_t *utils,
   dvalue = dbm_fetch(db, dkey);
   if (! dvalue.dptr) {
       utils->seterror(cntxt, SASL_NOLOG,
-		      "user: %s@%s property: %s not found in sasldb",
-		      authid, realm, propName);
+		      "user: %s@%s property: %s not found in sasldb %s",
+		      authid, realm, propName, path);
       result = SASL_NOUSER;
       goto cleanup;
   }
@@ -203,13 +203,17 @@ int _sasldb_putdata(const sasl_utils_t *utils,
     dvalue.dsize = data_len;
     if (dbm_store(db, dkey, dvalue, DBM_REPLACE)) {
 	utils->seterror(conn, 0,
-			"Couldn't update db");
+			"Couldn't update record for %s@%s property %s "
+			"in db %s: %s", authid, realm, propName, path,
+			strerror(errno));
 	result = SASL_FAIL;
     }
   } else {
       if (dbm_delete(db, dkey)) {
 	  utils->seterror(conn, 0,
-			  "Couldn't update db");
+			  "Couldn't delete record for %s@%s property %s "
+			  "in db %s: %s", authid, realm, propName, path,
+			  strerror(errno));
 	  result = SASL_NOUSER;
       }
   }


### PR DESCRIPTION
Officially declare the logging functions as "printf-like" to catch future argument-errors at compile-time.

Provide even more details, when reporting NDBM-operation failures.