### PR TITLE
saslcache: fix cast-as-lvalue usage

### DIFF
--- a/saslauthd/saslcache.c
+++ b/saslauthd/saslcache.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
 	}
 
 	table_stats = shm_base + 64;
-	(char *)table = (char *)table_stats + 128;
+	table = (void *)((char *)table_stats + 128);
 
 	if (dump_stat_info == 0 && dump_user_info == 0)
 		dump_stat_info = 1;


### PR DESCRIPTION
It is not allowed by modern C/C++ compilers, for example gcc>=4.