### PR TITLE
Avoid passing arbitrary strings as format strings in plugins

### DIFF
--- a/plugins/gs2.c
+++ b/plugins/gs2.c
@@ -1842,9 +1842,9 @@ sasl_gs2_seterror_(const sasl_utils_t *utils, OM_uint32 maj, OM_uint32 min,
     strcat(out, ")");
 
     if (logonly) {
-        utils->log(utils->conn, SASL_LOG_FAIL, out);
+        utils->log(utils->conn, SASL_LOG_FAIL, "%s", out);
     } else {
-        utils->seterror(utils->conn, 0, out);
+        utils->seterror(utils->conn, 0, "%s", out);
     }
     utils->free(out);
 

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -335,9 +335,9 @@ sasl_gss_seterror_(const sasl_utils_t *utils, OM_uint32 maj, OM_uint32 min,
     strcat(out, ")");
     
     if (logonly) {
-	utils->log(utils->conn, SASL_LOG_FAIL, out);
+	utils->log(utils->conn, SASL_LOG_FAIL, "%s", out);
     } else {
-	utils->seterror(utils->conn, 0, out);
+	utils->seterror(utils->conn, 0, "%s", out);
     }
     utils->free(out);
 

--- a/plugins/ldapdb.c
+++ b/plugins/ldapdb.c
@@ -316,7 +316,7 @@ static int ldapdb_auxprop_store(void *glob_context,
     sparams->utils->free(mods);
 
     if (i) {
-    	sparams->utils->seterror(sparams->utils->conn, 0,
+    	sparams->utils->seterror(sparams->utils->conn, 0, "%s",
 	    ldap_err2string(i));
 	if (i == LDAP_NO_MEMORY) i = SASL_NOMEM;
 	else i = SASL_FAIL;
@@ -416,7 +416,7 @@ ldapdb_canon_server(void *glob_context,
  done:
     if(cp.ld) ldap_unbind_ext(cp.ld, NULL, NULL);
     if (ret) {
-    	sparams->utils->seterror(sparams->utils->conn, 0,
+    	sparams->utils->seterror(sparams->utils->conn, 0, "%s",
 	    ldap_err2string(ret));
 	if (ret == LDAP_NO_MEMORY) ret = SASL_NOMEM;
 	else ret = SASL_FAIL;

--- a/plugins/scram.c
+++ b/plugins/scram.c
@@ -857,7 +857,8 @@ scram_server_mech_step1(server_context_t *text,
 				       &error_text);
 	if (result != SASL_OK) {
 	    if (error_text != NULL) {
-		sparams->utils->seterror(sparams->utils->conn, 0, error_text);
+		sparams->utils->seterror(sparams->utils->conn, 0, "%s",
+					 error_text);
 	    }
 	    goto cleanup;
 	}
@@ -1701,7 +1702,8 @@ static int scram_setpass(void *glob_context,
 				  &error_text);
 	if (r != SASL_OK) {
 	    if (error_text != NULL) {
-		SETERROR(sparams->utils, error_text);
+		sparams->utils->seterror(sparams->utils->conn, 0, "%s",
+					 error_text);
 	    }
 	    goto cleanup;
 	}


### PR DESCRIPTION
The GCC format-security warnings are treated as errors now on my machine and therefore prevent building.

Checking the code says, that they are indeed not a arbitrary strings, but static and well-defined in the code, but using format string should not hurt and makes GCC happy. See the commit messages for the warnings/errors details

just a note, that this jumped on me during the testing of `-rc5` build. I didn't see it before.