### PR TITLE
Document a way to run saslauthd unprivileged in systemd

### DIFF
--- a/saslauthd/saslauthd.mdoc
+++ b/saslauthd/saslauthd.mdoc
@@ -44,7 +44,31 @@ multi-user mode. When running against a protected authentication
 database (e.g. the
 .Li shadow
 mechanism),
-it must be run as the superuser.
+it must be run as the superuser. Otherwise it is recommended to run
+daemon unprivileged as saslauth:saslauth, requiring the runtime directory
+to have root:saslauthd owner. You can do so by following
+these steps in machines using
+.Xr systemd 1
+:
+
+.Bl -enum -compact
+.It
+create directory
+.Pa /etc/systemd/system/saslauthd.service.d/
+.It
+create file
+.Pa /etc/systemd/system/saslauthd.service.d/user.conf
+with content
+.Bd -literal
+[Service]
+User=saslauth
+Group=saslauth
+
+.Ed
+.It
+Reload systemd service file: run
+.Dq systemctl daemon-reload
+.El
 .Ss Options
 Options named by lower\-case letters configure the server itself.
 Upper\-case options control the behavior of specific authentication


### PR DESCRIPTION
This is a patch we have in Fedora for some time (slightly modified). I somehow skipped this one during the previous reviews. I hope it would be useful for upstream too. It might also be useful to add it in some other documentation .

https://src.fedoraproject.org/rpms/cyrus-sasl/blob/master/f/cyrus-sasl-2.1.26-saslauthd-user.patch