### PR TITLE
Several memory leaks/uninitialized memory accesses

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -1383,7 +1383,9 @@ const char *sasl_errdetail(sasl_conn_t *conn)
 	     sasl_usererr(conn->error_code), errstr);
     
     need_len = (unsigned) (strlen(leader) + strlen(conn->error_buf) + 12);
-    _buf_alloc(&conn->errdetail_buf, &conn->errdetail_buf_len, need_len);
+    if (_buf_alloc(&conn->errdetail_buf, &conn->errdetail_buf_len, need_len) != SASL_OK) {
+        return NULL;
+    }
 
     snprintf(conn->errdetail_buf, need_len, "%s%s", leader, conn->error_buf);
    

--- a/lib/dlopen.c
+++ b/lib/dlopen.c
@@ -303,6 +303,7 @@ static int _parse_la(const char *prefix, const char *in, char *out)
 	if(line[strlen(line) - 1] != '\n') {
 	    _sasl_log(NULL, SASL_LOG_WARN,
 		      "LA file has too long of a line: %s", in);
+	    fclose(file);
 	    return SASL_BUFOVER;
 	}
 	if(line[0] == '\n' || line[0] == '#') continue;
@@ -322,6 +323,7 @@ static int _parse_la(const char *prefix, const char *in, char *out)
 		if(ntmp == end) {
 		    _sasl_log(NULL, SASL_LOG_DEBUG,
 			      "dlname is empty in .la file: %s", in);
+		    fclose(file);
 		    return SASL_FAIL;
 		}
 		strcpy(out, prefix);

--- a/plugins/digestmd5.c
+++ b/plugins/digestmd5.c
@@ -550,6 +550,8 @@ static int add_to_challenge(const sasl_utils_t *utils,
 	/* Check if the value needs quoting */
 	if (strpbrk ((char *)value, NEED_ESCAPING) != NULL) {
 	    char * quoted = quote ((char *) value);
+	    if (quoted == NULL)
+		MEMERROR(utils);
 	    valuesize = strlen(quoted);
 	    /* As the quoted string is bigger, make sure we have enough
 	       space now */
@@ -756,6 +758,9 @@ static char *quote (char *str)
     }
 
     result = malloc (strlen(str) + num_to_escape + 1);
+    if (result == NULL) {
+        return NULL;
+    }
     for (p = str, outp = result; *p; p++) {
 	if (*p == '"' || *p == '\\') {
 	    *outp = '\\';

--- a/plugins/ldapdb.c
+++ b/plugins/ldapdb.c
@@ -81,7 +81,7 @@ typedef struct connparm {
 static int ldapdb_connect(ldapctx *ctx, sasl_server_params_t *sparams,
 	const char *user, unsigned ulen, connparm *cp)
 {
-    int i;
+    int i, rc;
     char *authzid;
 
     if((i=ldap_initialize(&cp->ld, ctx->uri))) {
@@ -100,7 +100,11 @@ static int ldapdb_connect(ldapctx *ctx, sasl_server_params_t *sparams,
     cp->c.ldctl_iscritical = 1;
 
     i = LDAP_VERSION3;
-    ldap_set_option(cp->ld, LDAP_OPT_PROTOCOL_VERSION, &i);
+    rc = ldap_set_option(cp->ld, LDAP_OPT_PROTOCOL_VERSION, &i);
+    if (rc != 0) {
+        sparams->utils->free(authzid);
+        return rc;
+    }
 
     /* If TLS is set and it fails, continue or bail out as requested */
     if (ctx->use_tls && (i=ldap_start_tls_s(cp->ld, NULL, NULL)) != LDAP_SUCCESS

--- a/plugins/ntlm.c
+++ b/plugins/ntlm.c
@@ -1398,6 +1398,13 @@ static int ntlm_server_mech_new(void *glob_context __attribute__((unused)),
     unsigned int len;
     SOCKET sock = (SOCKET) -1;
 
+    /* holds state are in: allocate early */
+    text = sparams->utils->malloc(sizeof(server_context_t));
+    if (text == NULL) {
+	MEMERROR( sparams->utils );
+	return SASL_NOMEM;
+    }
+
     sparams->utils->getopt(sparams->utils->getopt_context,
 			   "NTLM", "ntlm_server", &serv, &len);
     if (serv) {
@@ -1426,13 +1433,6 @@ static int ntlm_server_mech_new(void *glob_context __attribute__((unused)),
 
 	sparams->utils->free(tmp);
 	if (sock == (SOCKET) -1) return SASL_UNAVAIL;
-    }
-    
-    /* holds state are in */
-    text = sparams->utils->malloc(sizeof(server_context_t));
-    if (text == NULL) {
-	MEMERROR( sparams->utils );
-	return SASL_NOMEM;
     }
     
     memset(text, 0, sizeof(server_context_t));

--- a/saslauthd/saslauthd-main.c
+++ b/saslauthd/saslauthd-main.c
@@ -381,7 +381,7 @@ int main(int argc, char **argv) {
 char *do_auth(const char *_login, const char *password, const char *service, const char *realm) {
 
 	struct cache_result	lkup_result;
-	char			*response;
+	char			*response = NULL;
 	int			cached = 0;
 	char			login_buff[MAX_LOGIN_REALM_LEN];
 	char			*login;
@@ -438,6 +438,7 @@ char *do_auth(const char *_login, const char *password, const char *service, con
 	}
 
 	logger(L_ERR, L_FUNC, "mechanism returned unknown response: %s", auth_mech->name);
+	free(response);
 	response = strdup("NO internal mechanism failure");
 
 	return response;

--- a/saslauthd/testsaslauthd.c
+++ b/saslauthd/testsaslauthd.c
@@ -191,6 +191,7 @@ static int saslauthd_verify_password(const char *saslauthd_path,
 
     r = connect(s, (struct sockaddr *) &srvaddr, sizeof(srvaddr));
     if (r == -1) {
+        close(s);
         perror("connect() ");
 	return -1;
     }
@@ -202,9 +203,10 @@ static int saslauthd_verify_password(const char *saslauthd_path,
 	iov[0].iov_base = query;
 
 	if (retry_writev(s, iov, 1) == -1) {
-            fprintf(stderr,"write failed\n");
-  	    return -1;
-  	}
+	    close(s);
+	    fprintf(stderr,"write failed\n");
+	    return -1;
+	}
     }
   
     /*
@@ -213,8 +215,9 @@ static int saslauthd_verify_password(const char *saslauthd_path,
      * count result
      */
     if (retry_read(s, &count, sizeof(count)) < (int) sizeof(count)) {
+        close(s);
         fprintf(stderr,"size read failed\n");
-	return -1;
+        return -1;
     }
   
     count = ntohs(count);

--- a/utils/pluginviewer.c
+++ b/utils/pluginviewer.c
@@ -287,6 +287,9 @@ list_installed_server_mechanisms (
 	} else {
 	    /* This is suboptimal, but works */
 	    new_list = malloc (strlen(*list_of_mechs) + strlen(m->plug->mech_name) + 2);
+	    if (new_list == NULL) {
+		return;
+	    }
 	    sprintf (new_list, "%s %s", *list_of_mechs, m->plug->mech_name);
 	    free (*list_of_mechs);
 	    *list_of_mechs = new_list;
@@ -315,6 +318,9 @@ list_installed_client_mechanisms (
 	} else {
 	    /* This is suboptimal, but works */
 	    new_list = malloc (strlen(*list_of_mechs) + strlen(m->plug->mech_name) + 2);
+	    if (new_list == NULL) {
+		return;
+	    }
 	    sprintf (new_list, "%s %s", *list_of_mechs, m->plug->mech_name);
 	    free (*list_of_mechs);
 	    *list_of_mechs = new_list;
@@ -342,6 +348,9 @@ list_installed_auxprop_mechanisms (
     } else {
 	/* This is suboptimal, but works */
 	new_list = malloc (strlen(*list_of_mechs) + strlen(m->name) + 2);
+	if (new_list == NULL) {
+	    return;
+	}
 	sprintf (new_list, "%s %s", *list_of_mechs, m->name);
 	free (*list_of_mechs);
 	*list_of_mechs = new_list;

--- a/utils/saslpasswd.c
+++ b/utils/saslpasswd.c
@@ -265,7 +265,7 @@ main(int argc, char *argv[])
   int c;
   char *userid;
   char *password = NULL;
-  char *verify;
+  char *verify = NULL;
   unsigned passlen = 0;
   unsigned verifylen;
   const char *errstr = NULL;
@@ -406,10 +406,13 @@ main(int argc, char *argv[])
 		  &verifylen);
 	  if (passlen != verifylen
 	      || memcmp(password, verify, verifylen)) {
+	      free(verify);
+	      free(password);
 	      fprintf(stderr, "%s: passwords don't match; aborting\n", 
 		      progname);
 	      exit(-(SASL_BADPARAM));
 	  }
+	  free(verify);
       }
   }
 


### PR DESCRIPTION
Recent coverity scan results revealed  some more memory leaks, unchecked return values and uninitialized memory accesses.

This PR is not comprehensive fix of all the errors reported by coverity, but since I went through them, I fixed the most obvious cases.