### PR TITLE
Fallback gracefully for missing GSS_C_SEC_CONTEXT_SASL_SSF support in Heimdal

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -702,6 +702,9 @@ static int gssapi_get_ssf(context_t *text, sasl_ssf_t *mech_ssf)
     case GSS_S_UNAVAILABLE:
         /* Not supported by the library, fallback to default */
         goto fallback;
+    case GSS_S_FAILURE:
+        /* Not supported by Heimdal, fallback to default */
+        goto fallback;
     case GSS_S_COMPLETE:
         if ((bufset->count != 1) || (bufset->elements[0].length != 4)) {
             /* Malformed bufset, fail */


### PR DESCRIPTION
This addresses an issue introduced by commit ff9f9caeb6db6d7513128fff9321f9bd445f58b7, which breaks Heimdal backed GSSAPI authentication.