### PR TITLE
Set sasl error display string on GSS bit strength lookup failure

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -702,9 +702,6 @@ static int gssapi_get_ssf(context_t *text, sasl_ssf_t *mech_ssf)
     case GSS_S_UNAVAILABLE:
         /* Not supported by the library, fallback to default */
         goto fallback;
-    case GSS_S_FAILURE:
-        /* Not supported by Heimdal, fallback to default */
-        goto fallback;
     case GSS_S_COMPLETE:
         if ((bufset->count != 1) || (bufset->elements[0].length != 4)) {
             /* Malformed bufset, fail */
@@ -715,7 +712,15 @@ static int gssapi_get_ssf(context_t *text, sasl_ssf_t *mech_ssf)
         (void)gss_release_buffer_set(&min_stat, &bufset);
         *mech_ssf = ntohl(ssf);
         return SASL_OK;
+    case GSS_S_FAILURE:
+        /* Not supported by Heimdal, fallback to default */
+        if (min_stat == 0) {
+            goto fallback;
+        }
     default:
+        if (GSS_ERROR(maj_stat)) {
+            sasl_gss_seterror(text->utils,maj_stat,min_stat);
+        }
         return SASL_FAIL;
     }
 


### PR DESCRIPTION
Per @simo5, a failure should be honored/reported if minor status returns non-zero while retrieving the bit strength. See https://github.com/cyrusimap/cyrus-sasl/pull/497 for my previous attempt at this fix.