### PR TITLE
Fixes #525 -- Update for modern Heimdal API

### DIFF
--- a/sample/server.c
+++ b/sample/server.c
@@ -85,7 +85,11 @@
 
 #ifdef HAVE_GSS_GET_NAME_ATTRIBUTE
 #include <gssapi/gssapi.h>
+#ifndef KRB5_HEIMDAL
+#ifdef HAVE_GSSAPI_GSSAPI_EXT_H
 #include <gssapi/gssapi_ext.h>
+#endif
+#endif
 #endif
 
 #include "common.h"


### PR DESCRIPTION
Heimdal Kerberos added the gss_get_name_attribute function in 2011, but
the check in server.c was written in 2010.  Update the check to only
include gssapi_ext.h if the underlying Kerberos implementation is not
Heimdal.