### PR TITLE
Fixes #528 -- Honor plugindir setting

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -65,7 +65,7 @@ LIB_MYSQL = @LIB_MYSQL@
 
 plugindir = @plugindir@
 
-sasldir = $(prefix)/lib/sasl2
+sasldir = $(plugindir)
 sasl_LTLIBRARIES = @SASL_MECHS@
 EXTRA_LTLIBRARIES = libplain.la libanonymous.la libkerberos4.la libcrammd5.la \
 	libgs2.la libgssapiv2.la libdigestmd5.la liblogin.la libsrp.la libotp.la \


### PR DESCRIPTION
This fixes Makefile.am to correctly set sasldir to plugindir so that the
installation path for plugins set by configure is honored.