### PR TITLE
Allow saslauthd to be built outside of source tree and fix parallel build issue

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -149,4 +149,4 @@ passdss_init.c sasldb_init.c sql_init.c ldapdb_init.c
 CLEANFILES=$(init_src)
 
 ${init_src}: $(srcdir)/makeinit.sh
-	$(SHELL) $(srcdir)/makeinit.sh
+	$(SHELL) $(srcdir)/makeinit.sh $@

--- a/plugins/makeinit.sh
+++ b/plugins/makeinit.sh
@@ -1,7 +1,9 @@
+plugin_init="$1"
 # mechanism plugins
 for mech in anonymous crammd5 digestmd5 scram gssapiv2 kerberos4 login ntlm otp passdss plain srp gs2; do
+    if [ ${plugin_init} = "${mech}_init.c" ];then
 
-echo "
+        echo "
 #include <config.h>
 
 #include <string.h>
@@ -43,13 +45,16 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
 SASL_CLIENT_PLUG_INIT( $mech )
 SASL_SERVER_PLUG_INIT( $mech )
-" > ${mech}_init.c
+"       > ${mech}_init.c
+        echo "generating $1"
+    fi # End of `if [ ${plugin_init} = "${mech}_init.c" ];then'
 done
 
 # auxprop plugins
 for auxprop in sasldb sql ldapdb; do
+    if [ ${plugin_init} = "${auxprop}_init.c" ];then
 
-echo "
+        echo "
 #include <config.h>
 
 #include <string.h>
@@ -86,8 +91,12 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 #endif
 
 SASL_AUXPROP_PLUG_INIT( $auxprop )
-" > ${auxprop}_init.c
+"       > ${auxprop}_init.c
+        echo "generating $1"
+    fi # End of `if [ ${plugin_init} = "${auxprop}_init.c" ];then'
 done
 
 # ldapdb is also a canon_user plugin
-echo "SASL_CANONUSER_PLUG_INIT( ldapdb )" >> ldapdb_init.c
+if [ ${plugin_init} = "ldapdb_init.c" ];then
+    echo "SASL_CANONUSER_PLUG_INIT( ldapdb )" >> ldapdb_init.c
+fi

--- a/saslauthd/Makefile.am
+++ b/saslauthd/Makefile.am
@@ -34,7 +34,7 @@ saslcache_SOURCES = saslcache.c
 
 EXTRA_DIST	= saslauthd.8 saslauthd.mdoc include \
 		  getnameinfo.c getaddrinfo.c LDAP_SASLAUTHD
-AM_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)/../include -I$(top_builddir)/common
+AM_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_builddir)/common -I$(top_srcdir)/common
 DEFS            = @DEFS@ -DSASLAUTHD_CONF_FILE_DEFAULT=\"@sysconfdir@/saslauthd.conf\" -I. -I$(srcdir) -I..
 
 


### PR DESCRIPTION
…with `--enable-ldapdb'

[snip]
| powerpc-wrs-linux-gcc [snip] -I../common
|../../git/saslauthd/lak.c:58:10: fatal error: crypto-compat.h:
No such file or directory
[snip]

The crypto-compat.h locates in git/common/, it should be                                                                                                                           |
`-I../../git/common'

Remove useless `-I$(top_srcdir)/../include' which was incorrectly
added by commit `faae590 cleanup misc INCLUDES for different build paths'

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>