### PR TITLE
Convert obsolete HTML references to rst form.

### DIFF
--- a/docsrc/sasl/components.rst
+++ b/docsrc/sasl/components.rst
@@ -9,7 +9,7 @@ authentication system, there are a lot of different components
 that often cause confusion to users of the library who are trying to
 configure it for use on their system.  This document will try to provide
 some structure to all of these components, though you will also need
-to read the :ref:`System Administration <sysadmin>` to have a full
+to read the guide for SASL :ref:`System Administrators <sysadmin>` to have a full
 understanding of how to install SASL on your system.
 
 The first thing to realize is that there is a difference between SASL,
@@ -34,8 +34,8 @@ on-the-wire representation of the SASL negotiation, however it performs no
 analysis of the exchange itself.  It relies on the judgment of the SASL
 library whether authentication has occurred or not.  The application is also
 responsible for determining if the authenticated user may authorize as another
-user id (For more details on authentication and authorization identities
-and their differences, see <a href=sysadmin.html>Cyrus SASL for System Administrators</a>)
+user id (for more details on authentication and authorization identities
+and their differences, see the guide for SASL :ref:`System Administrators <sysadmin>`).
 
 Examples of applications are Cyrus IMAPd, OpenLDAP, Sendmail, Mutt,
 sieveshell, cyradm, and many others.

--- a/docsrc/sasl/quickstart.rst
+++ b/docsrc/sasl/quickstart.rst
@@ -42,8 +42,8 @@ routines.
 
 The sample directory in the code contains two programs which provide a reference
 for using the library, as well as making it easy to test a mechanism
-on the command line.  See <a
-href="programming.html">programming.html</a> for more information.
+on the command line.  See
+the :ref:`Application Programmer's Guide <programming>` for more information.
 
 This library is believed to be thread safe **if**:
 
@@ -77,8 +77,8 @@ Configuration
 There are two main ways to configure the SASL library for a given
 application.  The first (and typically easiest) is to make use
 of the application's configuration files.  Provided the application supports it
-(via the ``SASL_CB_GETOPT`` callback), please refer to that documetation
-for how to supply <a href=options.html>SASL options</a>.
+(via the ``SASL_CB_GETOPT`` callback), please refer to the documentation
+for how to supply :ref:`SASL options <options>`.
 
 Alternatively, Cyrus SASL looks for configuration files in
 /usr/lib/sasl/Appname.conf where Appname is settable by the

--- a/docsrc/sasl/sysadmin.rst
+++ b/docsrc/sasl/sysadmin.rst
@@ -295,7 +295,7 @@ Different SASL applications can use different srvtab files.
 
 A SASL application must be able to read its srvtab or keytab file.
 
-You may want to consult the <a href="gssapi.html">GSSAPI Tutorial</a>.</p>
+You may want to consult the :ref:`GSSAPI Tutorial <gssapi>`.
 
 The OTP mechanism
 -----------------


### PR DESCRIPTION
Files: sysadmin.rst, components.rst, quickstart.rst