### PR TITLE
dlopen: on osx the plugins are built as .so

### DIFF
--- a/lib/dlopen.c
+++ b/lib/dlopen.c
@@ -157,9 +157,8 @@ char *dlerror()
 #else
 #define SO_SUFFIX	".sl"
 #endif /* __ia64 */
-#elif defined(__APPLE__)
-#define SO_SUFFIX	".plugin"
-#else /* __APPLE__ */
+
+#else /* __hpux */
 #define SO_SUFFIX	".so"
 #endif
 


### PR DESCRIPTION
I have no idea why at some point it was changed to .plugin
but autotools defaults to .so and we are actually getting
.so files built.