### PR TITLE
Add missing string.h include for strcmp().

### DIFF
--- a/pwcheck/pwcheck_getspnam.c
+++ b/pwcheck/pwcheck_getspnam.c
@@ -42,6 +42,7 @@
  */
 
 #include <shadow.h>
+#include <string.h>
 
 extern char *crypt();
 


### PR DESCRIPTION
The file
pwcheck/pwcheck_getspnam.c
contains a call to strcmp(), but does not include string.h.

While this will sometimes work due to indirect includes of string.h or lenient compilers, it's not correct and you cannot rely on it. Therefore it's better to explicitly include headers for the functions used.

(I found this while going through the patches in the Gentoo package of cyrus-sasl, and this seemed obvious and simple enough to push upstream.)