### PR TITLE
openssl: Fix compilation without deprecated APIs

### DIFF
--- a/common/crypto-compat.c
+++ b/common/crypto-compat.c
@@ -12,7 +12,6 @@
 #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
 #include <string.h>
-#include <openssl/engine.h>
 
 static void *OPENSSL_zalloc(size_t num)
 {

--- a/common/crypto-compat.h
+++ b/common/crypto-compat.h
@@ -15,6 +15,7 @@
 #include <openssl/dh.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#include <openssl/bn.h>
 
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q);


### PR DESCRIPTION
bn.h was missing. Including engine.h does not work if OpenSSL was built
without it. cyrus-sasl makes no use of it anyway.