### PR TITLE
Fix build with -Wl,--as-needed

### DIFF
--- a/sasldb/Makefile.am
+++ b/sasldb/Makefile.am
@@ -54,6 +54,6 @@ noinst_LTLIBRARIES = libsasldb.la
 
 libsasldb_la_SOURCES = allockey.c sasldb.h
 EXTRA_libsasldb_la_SOURCES = $(extra_common_sources)
-libsasldb_la_DEPENDENCIES = $(SASL_DB_BACKEND)
-libsasldb_la_LIBADD = $(SASL_DB_BACKEND)
+libsasldb_la_DEPENDENCIES = $(SASL_DB_BACKEND) $(SASL_DB_LIB)
+libsasldb_la_LIBADD = $(SASL_DB_BACKEND) $(SASL_DB_LIB)
 libsasldb_la_LDFLAGS = -no-undefined


### PR DESCRIPTION
Fails with "x86_64-pc-linux-gnu-ld: ../sasldb/.libs/libsasldb.a(db_gdbm.o):
in function `_sasldb_getdata': db_gdbm.c:(.text+0xcf): undefined
reference to `gdbm_open'..." otherwise.