### PR TITLE
Restore LIBS after checking gss_inquire_sec_context_by_oid

### DIFF
--- a/m4/sasl2.m4
+++ b/m4/sasl2.m4
@@ -311,9 +311,10 @@ if test "$gssapi" != no; then
                     [AC_DEFINE(HAVE_GSS_C_SEC_CONTEXT_SASL_SSF,,
                                [Define if your GSSAPI implementation defines GSS_C_SEC_CONTEXT_SASL_SSF])])
   fi
+  LIBS="$cmu_save_LIBS"
+
   cmu_save_LIBS="$LIBS"
   LIBS="$LIBS $GSSAPIBASE_LIBS"
-
   AC_MSG_CHECKING([for SPNEGO support in GSSAPI libraries])
   AC_TRY_RUN([
 #ifdef HAVE_GSSAPI_H


### PR DESCRIPTION
4b0306dcd76031460246b2dabcb7db766d6b04d8 added a configure check for another GSSAPI function, however it forgot to restore `LIBS` after doing so.

The impact of this is that GSSAPI libs are included in **all** link lines, c.f. [this Debian build log](https://buildd.debian.org/status/fetch.php?pkg=cyrus-sasl2&arch=amd64&ver=2.1.27~rc8-1&stamp=1538479977&raw=0):

```
libtool: link: gcc -shared  -fPIC -DPIC  .libs/auxprop.o .libs/canonusr.o .libs/checkpw.o .libs/client.o .libs/common.o .libs/config.o .libs/external.o .libs/md5.o .libs/saslutil.o .libs/server.o .libs/seterror.o .libs/dlopen.o  -Wl,--whole-archive ../common/.libs/libplugin_common.a -Wl,--no-whole-archive  -L/usr/lib/x86_64-linux-gnu/heimdal -L/usr/x86_64-linux-gnu/lib -L/usr/lib -ldl -lresolv -lgssapi -lkrb5 -lasn1 -lroken -lcrypt -lcrypto -lcom_err  -g -O2 -fstack-protector-strong -Wl,--version-script=../../Versions -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -Wl,-z -Wl,defs -Wl,--enable-new-dtags -Wl,-rpath -Wl,/usr/lib/x86_64-linux-gnu/heimdal   -Wl,-soname -Wl,libsasl2.so.2 -o .libs/libsasl2.so.2.0.25
```

and resulted in extra unwanted dependencies:

```
 Package: libsasl2-2
 Depends: libsasl2-modules-db (>= 2.1.27~rc8-1), libc6 (>= 2.15), libcom-err2 (>= 1.43.9), libgssapi-krb5-2 (>= 1.6.dfsg.2), libk5crypto3 (>= 1.6.dfsg.2), libkrb5-3 (>= 1.6.dfsg.2)
```

This caused some problems for me when I [accidentally ended up with Heimdal and MIT libs in the same process](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=917129#15). This patch fixes the unwanted dependencies and the smbk5pwd breakage.

cc: @simo5 @brong 