### PR TITLE
db_gdbm: fix gdbm_errno overlay from gdbm_close

### DIFF
--- a/sasldb/db_gdbm.c
+++ b/sasldb/db_gdbm.c
@@ -107,9 +107,11 @@ int _sasldb_getdata(const sasl_utils_t *utils,
   gkey.dptr = key;
   gkey.dsize = key_len;
   gvalue = gdbm_fetch(db, gkey);
+  int fetch_errno = gdbm_errno;
+
   gdbm_close(db);
   if (! gvalue.dptr) {
-      if (gdbm_errno == GDBM_ITEM_NOT_FOUND) {
+      if (fetch_errno == GDBM_ITEM_NOT_FOUND) {
           utils->seterror(conn, SASL_NOLOG,
 			  "user: %s@%s property: %s not found in %s",
 			  authid, realm, propName, path);


### PR DESCRIPTION
`gdbm_close` also sets gdbm_errno since version 1.17.
This leads to a problem in `libsasl` as the `gdbm_close` incovation overlays
the `gdbm_errno` value which is then later used for the error handling.

Downstream bugs:
* Archlinux: https://bugs.archlinux.org/task/59873