### PR TITLE
Fix link to mailing list archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There's a mailing list for Cyrus SASL.  Subscribe by sending a message
 to majordomo@lists.andrew.cmu.edu with the body "subscribe
 cyrus-sasl". The mailing list is available via anonymous IMAP at
 imap://cyrus.andrew.cmu.edu/archive.cyrus-sasl or via the web at
-http://asg.web.cmu.edu/archive/mailbox.php3?mailbox=archive.cyrus-sasl.
+https://lists.andrew.cmu.edu/pipermail/cyrus-sasl/.
 
 If you are looking to port SASLv1 applications to SASLv2, please see
 doc/appconvert.html


### PR DESCRIPTION
The link in the README points to some dead address, update with the currently working one.