### PR TITLE
docsrc/index.rst: remove claiming support for SASL SR

### DIFF
--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -18,7 +18,7 @@ Features
 --------
 Cyrus SASL provides a number of authentication plugins out of the box.
 
-    Berkeley DB, GDBM, or NDBM (sasldb), PAM, MySQL, PostgreSQL, SQLite, LDAP, Active Directory(LDAP), DCE, Kerberos 4 and 5, proxied IMAP auth, getpwent, shadow, SIA, Courier Authdaemon, httpform, APOP and SASL mechanisms: ANONYMOUS, CRAM-MD5, DIGEST-MD5, EXTERNAL, GSSAPI, LOGIN, NTLM, OTP, PASSDSS, PLAIN, SR
+    Berkeley DB, GDBM, or NDBM (sasldb), PAM, MySQL, PostgreSQL, SQLite, LDAP, Active Directory(LDAP), DCE, Kerberos 4 and 5, proxied IMAP auth, getpwent, shadow, SIA, Courier Authdaemon, httpform, APOP and SASL mechanisms: ANONYMOUS, CRAM-MD5, DIGEST-MD5, EXTERNAL, GSSAPI, LOGIN, NTLM, OTP, PASSDSS, PLAIN.
 
 .. _SASL: https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer
 


### PR DESCRIPTION
In https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml there are no SASL SR or SRP mechanisms.