### PR TITLE
docsrc/exts/sphinxlocal: remove reference to docutils_version

### DIFF
--- a/docsrc/exts/sphinxlocal/writers/manpage.py
+++ b/docsrc/exts/sphinxlocal/writers/manpage.py
@@ -23,7 +23,6 @@ from sphinx.writers.manpage import (
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.util.osutil import ustrftime
-from sphinx.util.compat import docutils_version
 
 class CyrusManualPageWriter(ManualPageWriter):
 


### PR DESCRIPTION
New sphinx does not contain docutils_version in sphinx.util.compat and manpage.py does
not use it, so just do not import it.