### PR TITLE
lib/checkpw.c:saslauthd_verify_password: skip one strcat call

### DIFF
--- a/lib/checkpw.c
+++ b/lib/checkpw.c
@@ -676,8 +676,7 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
 	if (strlen(PATH_SASLAUTHD_RUNDIR) + 4 + 1 > sizeof(pwpath))
 	    return SASL_FAIL;
 
-	strcpy(pwpath, PATH_SASLAUTHD_RUNDIR);
-	strcat(pwpath, "/mux");
+	strcpy(pwpath, PATH_SASLAUTHD_RUNDIR "/mux");
     }
 
     /* Split out username/realm if necessary */


### PR DESCRIPTION
Since PATH_SASLAUTHD_RUNDIR and "/mux" are both fixed strings at compile time, they can be concatenated and handled as one string.