### PR TITLE
Fix potential out of bound writes

### DIFF
--- a/include/makemd5.c
+++ b/include/makemd5.c
@@ -104,12 +104,12 @@ my_strupr(char *s)
 #define BITSIZE(TYPE)						\
 {								\
     int b = 0; TYPE x = 1, zero = 0; char *pre = "U";		\
-    char tmp[128], tmp2[128];					\
+    char tmp[128] = {0}, tmp2[128] = {0};			\
     while(x){ x <<= 1; b++; if(x < zero) pre=""; }		\
     if(b >= len){						\
         int tabs;						\
-	sprintf(tmp, "%sINT%d" , pre, len/8);			\
-	sprintf(tmp2, "typedef %s %s;", #TYPE, tmp);		\
+	snprintf(tmp, 127, "%sINT%d" , pre, len/8);	    	\
+	snprintf(tmp2, 127, "typedef %s %s;", #TYPE, tmp);	\
 	my_strupr(tmp);						\
 	tabs = 5 - strlen(tmp2) / 8;				\
         fprintf(f, "%s", tmp2);					\


### PR DESCRIPTION
Silences Coverity

Although the code never passes in types that can cause the buffer
to actualy overflow, Coverity flags it, and the fix is simple.
