### PR TITLE
Fix man pages for sasl_decode64 and sasl_encode64

### DIFF
--- a/docsrc/sasl/reference/manpages/library/sasl_decode64.rst
+++ b/docsrc/sasl/reference/manpages/library/sasl_decode64.rst
@@ -16,7 +16,7 @@ Synopsis
 
     int sasl_decode64(const char * input,
                     unsigned inputlen,
-                   const char ** output,
+                   char * output,
                    unsigned outmax,
                    unsigned * outputlen);
 

--- a/docsrc/sasl/reference/manpages/library/sasl_encode64.rst
+++ b/docsrc/sasl/reference/manpages/library/sasl_encode64.rst
@@ -16,7 +16,7 @@ Synopsis
 
     int sasl_encode64(const char * input,
                     unsigned inputlen,
-                    const char ** output,
+                    char * output,
                     unsigned outmax,
                     unsigned * outputlen);
 


### PR DESCRIPTION
They declare the type of function argument "output" as

    const char **

but in the saslutil.h header it is declared as

    char *