### PR TITLE
plugins/gssapi: Implement credentials cache for delegation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,6 @@
+Joakim Ekblad <cyrussasl@aio.nu> implemented improvements in GSSAPI
+and Kerberos features on behalf of Vricon Systems AB
+
 Rob Siemborski <rjs3+@andrew.cmu.edu> wrote and tested the conversion
 to the SASLv2 API.
 

--- a/configure.ac
+++ b/configure.ac
@@ -506,15 +506,19 @@ if test "$gssapi" != "no"; then
   load_from_default="no"
 
   AC_CHECK_HEADERS(gssapi.h, [have_gss_header=y])
-  AC_SEARCH_LIBS(gss_acquire_cred_from, [gssapi_krb5 gssapi], [have_load_from=t])
-  if test x"${have_gss_header}" != x -a x"${have_load_from}" != x; then
-     load_from_defaults="yes"
+  AC_CHECK_HEADERS(gssapi/gssapi_ext.h, [have_gss_ext_header=y])
+  AC_SEARCH_LIBS(gss_acquire_cred_from, [gssapi_krb5], [have_load_from=t])
+  AC_SEARCH_LIBS(gss_store_cred_into, [gssapi_krb5], [have_store_into=t])
+
+  if test x"${have_gss_ext_header}" != x -a x"${have_load_from}" != x; then
+     load_from_default="yes"
+  fi
+  if test x"${have_gss_ext_header}" != x -a x"${have_store_into}" != x; then
+     ccache_default="yes"
   fi
 
   if test "$gss_impl" = "mit"; then
      mutex_default="yes"
-     ccache_default="yes"
-     load_from_default="yes"
   elif test "$gss_impl" = "heimdal"; then
      AC_DEFINE(KRB5_HEIMDAL,[],[Using Heimdal]) 
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -502,8 +502,19 @@ if test "$gssapi" != "no"; then
   AC_DEFINE(HAVE_GSSAPI,[],[Include GSSAPI/Kerberos 5 Support])
 
   mutex_default="no"
+  cc_default="no"
+  load_from_default="no"
+
+  AC_CHECK_HEADERS(gssapi.h, [have_gss_header=y])
+  AC_SEARCH_LIBS(gss_acquire_cred_from, [gssapi_krb5 gssapi], [have_load_from=t])
+  if test x"${have_gss_header}" != x -a x"${have_load_from}" != x; then
+     load_from_defaults="yes"
+  fi
+
   if test "$gss_impl" = "mit"; then
      mutex_default="yes"
+     cc_default="yes"
+     load_from_default="yes"
   elif test "$gss_impl" = "heimdal"; then
      AC_DEFINE(KRB5_HEIMDAL,[],[Using Heimdal]) 
   fi
@@ -516,6 +527,26 @@ if test "$gssapi" != "no"; then
      AC_DEFINE(GSS_USE_MUTEXES, [], [should we mutex-wrap calls into the GSS library?])
   fi
   AC_MSG_RESULT($use_gss_mutexes)
+
+  AC_MSG_CHECKING(to use GSS delgation with ccpath)
+  AC_ARG_ENABLE(gss_cc, [  --enable-gss-cc         allow delegation of cached crdentials],
+                use_gss_cc=$enableval,
+                use_gss_cc=$cc_default)
+
+  if test $use_gss_cc = "yes"; then
+     AC_DEFINE(GSS_USE_CC, [], [should we allow storage of cached credentials?])
+  fi
+  AC_MSG_RESULT($use_gss_cc)
+
+  AC_MSG_CHECKING(to use GSS service keytab loading with gss_acquire_cred_from)
+  AC_ARG_ENABLE(gss_load_from, [  --enable-gss-load-from  allow GSSProxy friendly keytab load],
+                use_gss_load_from=$enableval,
+                use_gss_load_from=$load_from_default)
+
+  if test $use_gss_load_from = "yes"; then
+     AC_DEFINE(GSS_USE_LOAD_FROM, [], [should we use gss_acquire_cred_from?])
+  fi
+  AC_MSG_RESULT($use_gss_load_from)
 fi
 
 SASL2_CRYPT_CHK
@@ -1218,6 +1249,30 @@ if test $sasl_cv_getnameinfo = yes; then
 fi
 AC_SUBST(GETNAMEINFOOBJS)
 AC_SUBST(LTGETNAMEINFOOBJS)
+
+dnl check for getpwnam
+sasl_cv_getpwnam=no
+AC_CHECK_FUNC(getpwnam, [AC_DEFINE(HAVE_GETPWNAM,[],
+	[do we have getpwnam()?])], [sasl_cv_getpwnam=yes])
+AC_SUBST(GETPWNAM)
+
+dnl check for getuid
+sasl_cv_getuid=no
+AC_CHECK_FUNC(getuid, [AC_DEFINE(HAVE_GETUID,[],
+	[do we have getuid()?])], [sasl_cv_getuid=yes])
+AC_SUBST(GETUID)
+
+dnl check for getlogin_r
+sasl_cv_getlogin_r=no
+AC_CHECK_FUNC(getlogin_r, [AC_DEFINE(HAVE_GETLOGIN_R,[],
+	[do we have getlogin_r()?])], [sasl_cv_getlogin_r=yes])
+AC_SUBST(GETLOGIN_R)
+
+dnl check for getpid
+sasl_cv_getpid=no
+AC_CHECK_FUNC(getpid, [AC_DEFINE(HAVE_GETPID,[],
+	[do we have getpid()?])], [sasl_cv_getpid=yes])
+AC_SUBST(GETPID)
 
 LTLIBOBJS=`echo "$LIB@&t@OBJS" | sed 's,\.[[^.]]* ,.lo ,g;s,\.[[^.]]*$,.lo,'`
 AM_CONDITIONAL(BUILD_LIBOBJ, test "$LTLIBOBJS" != "")

--- a/configure.ac
+++ b/configure.ac
@@ -502,7 +502,7 @@ if test "$gssapi" != "no"; then
   AC_DEFINE(HAVE_GSSAPI,[],[Include GSSAPI/Kerberos 5 Support])
 
   mutex_default="no"
-  cc_default="no"
+  ccache_default="no"
   load_from_default="no"
 
   AC_CHECK_HEADERS(gssapi.h, [have_gss_header=y])
@@ -513,7 +513,7 @@ if test "$gssapi" != "no"; then
 
   if test "$gss_impl" = "mit"; then
      mutex_default="yes"
-     cc_default="yes"
+     ccache_default="yes"
      load_from_default="yes"
   elif test "$gss_impl" = "heimdal"; then
      AC_DEFINE(KRB5_HEIMDAL,[],[Using Heimdal]) 
@@ -528,15 +528,15 @@ if test "$gssapi" != "no"; then
   fi
   AC_MSG_RESULT($use_gss_mutexes)
 
-  AC_MSG_CHECKING(to use GSS delgation with ccpath)
-  AC_ARG_ENABLE(gss_cc, [  --enable-gss-cc         allow delegation of cached crdentials],
-                use_gss_cc=$enableval,
-                use_gss_cc=$cc_default)
+  AC_MSG_CHECKING(to use GSS delgation with ccache store)
+  AC_ARG_ENABLE(gss_ccache, [  --enable-gss-ccache       allow delegation of cached crdentials],
+                use_gss_ccache=$enableval,
+                use_gss_ccache=$ccache_default)
 
-  if test $use_gss_cc = "yes"; then
-     AC_DEFINE(GSS_USE_CC, [], [should we allow storage of cached credentials?])
+  if test $use_gss_ccache = "yes"; then
+     AC_DEFINE(GSS_USE_CCACHE_STORE, [], [should we allow storage of cached credentials?])
   fi
-  AC_MSG_RESULT($use_gss_cc)
+  AC_MSG_RESULT($use_gss_ccache)
 
   AC_MSG_CHECKING(to use GSS service keytab loading with gss_acquire_cred_from)
   AC_ARG_ENABLE(gss_load_from, [  --enable-gss-load-from  allow GSSProxy friendly keytab load],

--- a/docsrc/sasl/options.rst
+++ b/docsrc/sasl/options.rst
@@ -114,7 +114,7 @@ GSSAPI
 
    If this option is omitted, credentials delegation will not be enabled.
 
-   See MIT Kerberos documentation on more informatino about credentials
+   See MIT Kerberos documentation on more information about credentials
    cache storage.
 
    Default: None, if omitted, no credentials cache/delegation and if left

--- a/docsrc/sasl/options.rst
+++ b/docsrc/sasl/options.rst
@@ -96,7 +96,7 @@ GSSAPI
 
    Default: /etc/krb5.keytab (system dependant)
 
-.. option:: ccache [<path>]
+.. option:: ccache_store [<path>]
 
    Location where cached credentials are stored, For example this could
    be FILE:/path/to/credstore/krb5cc_%U. Formatting options are:

--- a/docsrc/sasl/options.rst
+++ b/docsrc/sasl/options.rst
@@ -96,6 +96,30 @@ GSSAPI
 
    Default: /etc/krb5.keytab (system dependant)
 
+.. option:: ccache [<path>]
+
+   Location where cached credentials are stored, For example this could
+   be FILE:/path/to/credstore/krb5cc_%U. Formatting options are:
+
+   %u UID of the logged in user (only valid for existing UNIX users)
+   %U username of the logged in user
+   %e EUID of the executing process user
+   %E username of the executing process user
+   %p PID process ID of the executing process
+
+   Note that not all formatting options may not be available for all target
+   environments. See the log files for indications in run-time. If this
+   option can not be parsed correctly credentials cache will fall-back to
+   the contents of the KRB5CCNAME environment variable.
+
+   If this option is omitted, credentials delegation will not be enabled.
+
+   See MIT Kerberos documentation on more informatino about credentials
+   cache storage.
+
+   Default: None, if omitted, no credentials cache/delegation and if left
+   empty or invalid KRB5CCNAME will be used.
+
 LDAPDB
 ======
 

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -901,7 +901,7 @@ static char* resolve_ccache_store(context_t* text, const char* username, const c
             }
 #else
             text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                                  "GSSAPI error: %u is supported in ccache store format");
+                                  "GSSAPI error: %%u is unsupported in ccache store format");
             goto parsing_failed;
 #endif
             break;
@@ -920,7 +920,7 @@ static char* resolve_ccache_store(context_t* text, const char* username, const c
             }
 #else
             text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                                  "GSSAPI error: %%e is supported in ccache store format");
+                                  "GSSAPI error: %%e is unsupported in ccache store format");
             goto parsing_failed;
 #endif
             break;
@@ -934,7 +934,7 @@ static char* resolve_ccache_store(context_t* text, const char* username, const c
             }
 #else
             text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                                  "GSSAPI error: %%E is supported in ccache store format");
+                                  "GSSAPI error: %%E is unsupported in ccache store format");
             goto parsing_failed;
 #endif
             break;
@@ -950,7 +950,7 @@ static char* resolve_ccache_store(context_t* text, const char* username, const c
             }
 #else
             text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                                  "GSSAPI error: %%p is supported in ccache store format");
+                                  "GSSAPI error: %%p is unsupported in ccache store format");
             goto parsing_failed;
 #endif
             break;

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1158,16 +1158,10 @@ gssapi_server_mech_authneg(context_t *text,
 	    GSS_LOCK_MUTEX_CTX(params->utils, text);
 #ifdef GSS_USE_LOAD_FROM
             if (keytab != NULL) {
-                gss_key_value_element_desc ccache_element = {.key = "ccache", .value = NULL};
                 gss_key_value_element_desc keytab_element = {.key = "keytab", .value = keytab};
-                gss_key_value_element_desc elements[2];
-                gss_key_value_set_desc cred_store = {.elements = &ccache_element, .count = 1};
-              
-                elements[0] = ccache_element;
-                elements[1] = keytab_element;
-                cred_store.count = 2;
-                cred_store.elements = elements;
-              
+                gss_key_value_element_desc elements[1] = {keytab_element};
+                gss_key_value_set_desc cred_store = {.elements = elements, .count = 1};
+
                 params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
                                    "GSSAPI server acquire cred from %s", keytab);
 

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -88,7 +88,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#ifdef GSS_USE_CC
+#ifdef GSS_USE_CCACHE_STORE
 #include <sys/stat.h>
 #ifdef HAVE_GETPWNAM
 #include <pwd.h>
@@ -206,8 +206,8 @@ typedef struct context {
     char *authid; /* hold the authid between steps - server */
     const char *user;   /* hold the userid between steps - client */
     void *ctx_mutex; /* A per-context mutex */
-#ifdef GSS_USE_CC
-    const char* ccname;
+#ifdef GSS_USE_CCACHE_STORE
+    char* ccname;
 #endif
 } context_t;
 
@@ -593,7 +593,7 @@ static int sasl_gss_free_context_contents(context_t *text)
 	text->server_name = GSS_C_NO_NAME;
     }
 
-#ifdef GSS_USE_CC
+#ifdef GSS_USE_CCACHE_STORE
     if (text->ccname) {
       free(text->ccname);
       text->ccname = NULL;
@@ -829,226 +829,227 @@ gssapi_server_mech_new(void *glob_context,
     return SASL_OK;
 }
 
-#ifdef GSS_USE_CC
+#ifdef GSS_USE_CCACHE_STORE
 static char* strsubst(context_t* text, const char* haystack, const char* needle, const char* subst) {
-  const size_t haystack_len = strlen(haystack);
-  const size_t needle_len = strlen(needle);
-  const size_t subst_len = strlen(subst);
-  const size_t dest_len = haystack_len - needle_len + subst_len;
-  const char* needle_ptr = strstr(haystack, needle);
-  const size_t pre_needle_len = needle_ptr - haystack;
-  char* d;
+    const size_t haystack_len = strlen(haystack);
+    const size_t needle_len = strlen(needle);
+    const size_t subst_len = strlen(subst);
+    const size_t dest_len = haystack_len - needle_len + subst_len;
+    const char* needle_ptr = strstr(haystack, needle);
+    const size_t pre_needle_len = needle_ptr - haystack;
+    char* d;
 
-  if ((NULL == haystack) || (NULL == needle) || (NULL == subst)) {
-    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                          "GSSAPI error: Bad ccache format");
-    return NULL;
-  }
+    if ((NULL == haystack) || (NULL == needle) || (NULL == subst)) {
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI error: Bad ccache store format");
+        return NULL;
+    }
 
-  if (NULL == (d = malloc(dest_len + 1))) {
-    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                          "GSSAPI error: Out of memory processing ccache");
-    return NULL;
-  }
+    if (NULL == (d = malloc(dest_len + 1))) {
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI error: Out of memory processing ccache store format");
+        return NULL;
+    }
 
-  strncpy(d, haystack, pre_needle_len);
-  d[pre_needle_len] = 0;
-  strcat(d, subst);
-  strcat(d, &haystack[pre_needle_len + needle_len]);
+    strncpy(d, haystack, pre_needle_len);
+    d[pre_needle_len] = 0;
+    strcat(d, subst);
+    strcat(d, &haystack[pre_needle_len + needle_len]);
 
-  return d;
+    return d;
 }
 
-static char* create_krb5_ccache(context_t* text, const char* username, const char* ccache) {
-  char* ccname = NULL;
-  char* ccache_copy = NULL;
-  char* needle;
-
-  if (NULL == ccache) {
-    goto noccache;
-  }
-
-  /* Empty string will result in default value */
-  if (0 == strcmp("", ccache)) {
-    goto noccache;
-  }
-
-  if (NULL == username) {
-    goto sanity_check_failed;
-  }
-
-  if (NULL == (ccache_copy = strdup(ccache))) {
-    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                          "GSSAPI error: out of memory");
-    goto malloc_failed;
-  }
-
-  while (NULL != (needle = strstr(ccache_copy, "%"))) {
-    if (NULL != ccname) {
-      /* Every iteration starts with a fresh destination string */
-      free(ccname);
-      ccname = NULL;
+static char* resolve_ccache_store(context_t* text, const char* username, const char* ccache) {
+    char* ccname = NULL;
+    char* ccache_copy = NULL;
+    char* needle;
+    
+    if (NULL == ccache) {
+        goto noccache;
     }
 
-    switch (needle[1]) {
-    case 'u': {
-#ifdef HAVE_GETPWNAM
-      char uid_str[100];
-      struct passwd* pwd = getpwnam(username);
-      sprintf(uid_str, "%d", pwd->pw_uid);
-      if (NULL == (ccname = strsubst(text, ccache_copy, "%u", uid_str))) {
-        goto parsing_failed;
-      }
-#else
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: %u is supported in ccache");
-      goto parsing_failed;
-#endif
-      break;
-    }
-    case 'U': {
-      ccname = strsubst(text, ccache_copy, "%U", username);
-      break;
-    }
-    case 'e': {
-#ifdef HAVE_GETEUID
-      char euid_str[100];
-      uid_t euid = geteuid();
-      sprintf(euid_str, "%ul", euid);
-      if (NULL == (ccname = strsubst(text, ccache_copy, "%e", euid_str))) {
-        goto parsing_failed;
-      }
-#else
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: %%e is supported in ccache");
-      goto parsing_failed;
-#endif
-      break;
-    }
-    case 'E': {
-#ifdef HAVE_GETLOGIN_R
-      char server_username[100];
-      getlogin_r(server_username, sizeof(server_username));
-      if (NULL == (ccname = strsubst(text, ccache_copy, "%E", server_username))) {
-        goto parsing_failed;
-      }
-#else
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: %%E is supported in ccache");
-      goto parsing_failed;
-#endif
-      break;
-    }
-    case 'p': {
-#ifdef HAVE_GETPID
-      char pid_str[100];
-      pid_t pid;
-      pid = getpid();
-      sprintf(pid_str, "%d", pid);
-      if (NULL == (ccname = strsubst(text, ccache_copy, "%p", pid_str))) {
-        goto parsing_failed;
-      }
-#else
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: %%p is supported in ccache");
-      goto parsing_failed;
-#endif
-      break;
-    }
-    default:
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: invalid ccache format");
-      goto invalid_ccache_format;
-      break;
+    /* Empty string will result in default value */
+    if (0 == strcmp("", ccache)) {
+        goto noccache;
     }
 
-    free(ccache_copy);
-    if (NULL != ccname) {
-      ccache_copy = strdup(ccname);
-      if (NULL == ccache_copy) {
+    if (NULL == username) {
+        goto sanity_check_failed;
+    }
+
+    if (NULL == (ccache_copy = strdup(ccache))) {
         text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
                               "GSSAPI error: out of memory");
         goto malloc_failed;
-      }
     }
-  }
 
-  if ((NULL == ccname) && (NULL != ccache)) {
-    if (NULL == (ccname = strdup(ccache))) {
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: out of memory");
-      goto malloc_failed;
+    while (NULL != (needle = strchr(ccache_copy, '%'))) {
+        if (NULL != ccname) {
+            /* Every iteration starts with a fresh destination string */
+          free(ccname);
+          ccname = NULL;
+        }
+
+        switch (needle[1]) {
+        case 'u': {
+#ifdef HAVE_GETPWNAM
+            char uid_str[100];
+            struct passwd* pwd = getpwnam(username);
+            sprintf(uid_str, "%d", pwd->pw_uid);
+            if (NULL == (ccname = strsubst(text, ccache_copy, "%u", uid_str))) {
+                goto parsing_failed;
+            }
+#else
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: %u is supported in ccache store format");
+            goto parsing_failed;
+#endif
+            break;
+        }
+        case 'U': {
+            ccname = strsubst(text, ccache_copy, "%U", username);
+            break;
+        }
+        case 'e': {
+#ifdef HAVE_GETEUID
+            char euid_str[100];
+            uid_t euid = geteuid();
+            sprintf(euid_str, "%ul", euid);
+            if (NULL == (ccname = strsubst(text, ccache_copy, "%e", euid_str))) {
+                goto parsing_failed;
+            }
+#else
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: %%e is supported in ccache store format");
+            goto parsing_failed;
+#endif
+            break;
+        }
+        case 'E': {
+#ifdef HAVE_GETLOGIN_R
+            char server_username[100];
+            getlogin_r(server_username, sizeof(server_username));
+            if (NULL == (ccname = strsubst(text, ccache_copy, "%E", server_username))) {
+                goto parsing_failed;
+            }
+#else
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: %%E is supported in ccache store format");
+            goto parsing_failed;
+#endif
+            break;
+        }
+        case 'p': {
+#ifdef HAVE_GETPID
+            char pid_str[100];
+            pid_t pid;
+            pid = getpid();
+            sprintf(pid_str, "%d", pid);
+            if (NULL == (ccname = strsubst(text, ccache_copy, "%p", pid_str))) {
+                goto parsing_failed;
+            }
+#else
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: %%p is supported in ccache store format");
+            goto parsing_failed;
+#endif
+            break;
+        }
+        default:
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: invalid ccache store format");
+            goto invalid_ccache_format;
+            break;
+        }
+
+        free(ccache_copy);
+        if (NULL != ccname) {
+            ccache_copy = strdup(ccname);
+            if (NULL == ccache_copy) {
+                text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                      "GSSAPI error: out of memory");
+                goto malloc_failed;
+            }
+        }
     }
-  }
 
-  goto ok;
+    if ((NULL == ccname) && (NULL != ccache)) {
+        if (NULL == (ccname = strdup(ccache))) {
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: out of memory");
+            goto malloc_failed;
+        }
+    }
+
+    goto ok;
  invalid_ccache_format:
  malloc_failed:
  sanity_check_failed:
  parsing_failed:
-  if (NULL != ccname) {
-    free(ccname);
-    ccname = NULL;
-  }
- noccache:
-  if (NULL == ccname) {
-    ccname = strdup(getenv("KRB5CCNAME"));
-    if (NULL == ccname) {
-      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                            "GSSAPI error: out of memory");
+    if (NULL != ccname) {
+        free(ccname);
+        ccname = NULL;
     }
-    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                          "GSSAPI warning: using KRB5CCNAME for ccache");
-  }
+ noccache:
+    if (NULL == ccname) {
+        ccname = strdup(getenv("KRB5CCNAME"));
+        if (NULL == ccname) {
+            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                  "GSSAPI error: out of memory, or KRB5CCNAME unset");
+        }
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI warning: using KRB5CCNAME for ccache store");
+    }
  ok:
-  if (NULL != ccache_copy) {
-    free(ccache_copy);
-  }
-  return ccname;
+    if (NULL != ccache_copy) {
+        free(ccache_copy);
+    }
+
+    return ccname;
 }
 
 static char *store_client_credentials(context_t* text, gss_cred_id_t* client_credentials, const char* username, const char* ccache) {
-  gss_key_value_element_desc element;
-  gss_key_value_set_desc store;
-  char* ccname = NULL;
-  OM_uint32 maj_stat;
-  OM_uint32 min_stat;
+    gss_key_value_element_desc element;
+    gss_key_value_set_desc store;
+    char* ccname = NULL;
+    OM_uint32 maj_stat;
+    OM_uint32 min_stat;
 
-  if (NULL == (ccname = create_krb5_ccache(text, username, ccache))) {
-    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-			  "GSSAPI error: unable to generate krb5cc filename");
-    goto create_krb5_ccache_failed;
-  }
+    if (NULL == (ccname = resolve_ccache_store(text, username, ccache))) {
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI error: unable to generate krb5cc store name");
+        goto resolve_ccache_store_failed;
+    }
 
-  element.key = "ccache";
-  element.value = ccname;
-  store.elements = &element;
-  store.count = 1;
+    element.key = "ccache";
+    element.value = ccname;
+    store.elements = &element;
+    store.count = 1;
 
-  maj_stat = gss_store_cred_into(&min_stat,
-                                 *client_credentials,
-                                 GSS_C_INITIATE,
-                                 GSS_C_NULL_OID,
-                                 1,
-                                 1,
-                                 &store,
-                                 NULL,
-                                 NULL);
+    maj_stat = gss_store_cred_into(&min_stat,
+                                   *client_credentials,
+                                   GSS_C_INITIATE,
+                                   GSS_C_NULL_OID,
+                                   1,
+                                   1,
+                                   &store,
+                                   NULL,
+                                   NULL);
 
-  if (GSS_S_COMPLETE != maj_stat) {
-    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-			  "GSSAPI error: unable to store credentials in krb5cc file");
-    goto gss_store_cred_into_failed;
-  }
+    if (GSS_S_COMPLETE != maj_stat) {
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI error: unable to store credentials in krb5cc store");
+        goto gss_store_cred_into_failed;
+    }
 
-  goto ok;
+    goto ok;
 
  gss_store_cred_into_failed:
-  free(ccname);
-  ccname = NULL;
- create_krb5_ccache_failed:
+    free(ccname);
+    ccname = NULL;
+ resolve_ccache_store_failed:
  ok:
-  return ccname;
+    return ccname;
 }
 #endif
 
@@ -1126,16 +1127,19 @@ gssapi_server_mech_authneg(context_t *text,
 #endif
 	    GSS_LOCK_MUTEX_CTX(params->utils, text);
 #ifdef GSS_USE_LOAD_FROM
-            if (keytab != NULL) { /* Force cached credentials to use GSS Proxy compliant API of GSS */
+            if (keytab != NULL) {
                 gss_key_value_element_desc ccache_element = {.key = "ccache", .value = NULL};
                 gss_key_value_element_desc keytab_element = {.key = "keytab", .value = keytab};
                 gss_key_value_element_desc elements[2];
                 gss_key_value_set_desc cred_store = {.elements = &ccache_element, .count = 1};
-
+              
                 elements[0] = ccache_element;
                 elements[1] = keytab_element;
                 cred_store.count = 2;
-		cred_store.elements = elements;
+                cred_store.elements = elements;
+              
+                params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
+                                   "GSSAPI server acquire cred from %s", keytab);
 
                 maj_stat = gss_acquire_cred_from(&min_stat,
                                                  text->server_name,
@@ -1147,8 +1151,9 @@ gssapi_server_mech_authneg(context_t *text,
                                                  NULL,
                                                  NULL);
             }
-            else {
+            else
 #endif
+            {
                 maj_stat = gss_acquire_cred(&min_stat,
                                             text->server_name,
                                             GSS_C_INDEFINITE,
@@ -1157,9 +1162,8 @@ gssapi_server_mech_authneg(context_t *text,
                                             &text->server_creds, 
                                             NULL,
                                             NULL);
-#ifdef GSS_USE_LOAD_FROM
             }
-#endif
+
 	    GSS_UNLOCK_MUTEX_CTX(params->utils, text);
 
 	    if (GSS_ERROR(maj_stat)) {
@@ -1256,7 +1260,7 @@ gssapi_server_mech_authneg(context_t *text,
     } else {
 	text->qop = LAYER_NONE | LAYER_INTEGRITY | LAYER_CONFIDENTIALITY;
     }
-#ifdef GSS_USE_CC
+#ifdef GSS_USE_CCACHE_STORE
     if (text->ccname) {
         params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS; /* Force delegation flag */
     }
@@ -1371,19 +1375,18 @@ gssapi_server_mech_authneg(context_t *text,
 	goto cleanup;
     }
 
-#ifdef GSS_USE_CC
-    /* Get ccache from sasl-config file if located elsewhere than /tmp */
+#ifdef GSS_USE_CCACHE_STORE
     if (GSS_C_NO_CREDENTIAL != text->client_creds) {
         const char* ccache = NULL;
         const sasl_utils_t *utils = text->utils;
         unsigned int rl;
-        utils->getopt(utils->getopt_context, "GSSAPI", "ccache", (const char**)&ccache, &rl);
+        utils->getopt(utils->getopt_context, "GSSAPI", "ccache_store", (const char**)&ccache, &rl);
         if (NULL == ccache) {
             text->ccname = NULL;
         }
         else {
-            text->ccname = (const char*)store_client_credentials(text, &(text->client_creds),
-                                                                 name_token.value, ccache);
+            text->ccname = store_client_credentials(text, &(text->client_creds),
+                                                    name_token.value, ccache);
         }
     }
 #endif
@@ -2001,7 +2004,7 @@ static int gssapi_client_mech_step(void *conn_context,
 		
 		return SASL_INTERACT;
 	    }
-	}
+        }
 	    
 	if (text->server_name == GSS_C_NO_NAME) { /* only once */
 	    if (params->serverFQDN == NULL
@@ -2067,9 +2070,9 @@ static int gssapi_client_mech_step(void *conn_context,
 		req_flags |= GSS_C_CONF_FLAG;
 	    }
 	}
-#ifdef GSS_USE_CC
+#ifdef GSS_USE_CCACHE_STORE
 	if (text->ccname) {
-            params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS; /* Force delegation */
+            params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS;
 	}
 #endif
 	if (params->props.security_flags & SASL_SEC_PASS_CREDENTIALS) {

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -830,6 +830,17 @@ gssapi_server_mech_new(void *glob_context,
 }
 
 #ifdef GSS_USE_CCACHE_STORE
+static char* resolve_ccname_from_env(context_t* text) {
+    char* ccname = strdup(getenv("KRB5CCNAME"));
+    if (NULL == ccname) {
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI error: out of memory, or KRB5CCNAME unset");
+    }
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                          "GSSAPI warning: using KRB5CCNAME for ccache store");
+    return ccname;
+}
+
 static char* strsubst(context_t* text, const char* haystack, const char* needle, const char* subst) {
     const size_t haystack_len = strlen(haystack);
     const size_t needle_len = strlen(needle);
@@ -1017,13 +1028,7 @@ static char* resolve_ccache_store(context_t* text, const char* username, const c
     }
  noccache:
     if (NULL == ccname) {
-        ccname = strdup(getenv("KRB5CCNAME"));
-        if (NULL == ccname) {
-            text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                                  "GSSAPI error: out of memory, or KRB5CCNAME unset");
-        }
-        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
-                              "GSSAPI warning: using KRB5CCNAME for ccache store");
+        ccache = resolve_ccname_from_env(text);
     }
  ok:
     if (NULL != ccache_copy) {

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -894,7 +894,32 @@ static char* resolve_ccache_store(context_t* text, const char* username, const c
         case 'u': {
 #ifdef HAVE_GETPWNAM
             char uid_str[100];
-            struct passwd* pwd = getpwnam(username);
+            struct passwd* pwd;
+            size_t username_len;
+            char* username_wo_realm;
+            const char* at_sign_at = strchr(username, '@');
+            /* Strip @REALM part, if available, since password database most likely wont contain it */
+            if (NULL != at_sign_at) {
+              username_len = at_sign_at - username;
+            }
+            else {
+              username_len = strlen(username);
+            }
+            username_wo_realm = malloc(username_len + 1);
+            if (NULL == username_wo_realm) {
+                text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                      "GSSAPI error: out of memory");
+                goto parsing_failed;
+            }
+            username_wo_realm[username_len] = '\0';
+            strncpy(username_wo_realm, username, username_len);
+            pwd = getpwnam(username_wo_realm);
+            free(username_wo_realm);
+            if (NULL == pwd) {
+                text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                                      "GSSAPI error: ccache store with %%u can not be resolved for '%s'", username);
+                goto parsing_failed;
+            }
             sprintf(uid_str, "%d", pwd->pw_uid);
             if (NULL == (ccname = strsubst(text, ccache_copy, "%u", uid_str))) {
                 goto parsing_failed;
@@ -1261,9 +1286,8 @@ gssapi_server_mech_authneg(context_t *text,
 	text->qop = LAYER_NONE | LAYER_INTEGRITY | LAYER_CONFIDENTIALITY;
     }
 #ifdef GSS_USE_CCACHE_STORE
-    if (text->ccname) {
-        params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS; /* Force delegation flag */
-    }
+    /* TODO: This should maybe depend on "pass_credentials" (server-side), or Kerberos token attributes */
+    params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS; /* Force delegation flag */
 #endif
     if ((params->props.security_flags & SASL_SEC_PASS_CREDENTIALS) &&
 	(!(out_flags & GSS_C_DELEG_FLAG) ||
@@ -1387,6 +1411,16 @@ gssapi_server_mech_authneg(context_t *text,
         else {
             text->ccname = store_client_credentials(text, &(text->client_creds),
                                                     name_token.value, ccache);
+            if (NULL == text->ccname) {
+                params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
+                                   "GSSAPI server could not store credentials cache %s for %s",
+                                   ccache, name_token.value);
+                /* Non breaking error, users will just not be able to authenticate to underlying services */
+            }
+            else {
+                params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
+                                   "GSSAPI server saved credentials cache %s for %s", ccache, name_token.value);
+            }
         }
     }
 #endif
@@ -2071,9 +2105,8 @@ static int gssapi_client_mech_step(void *conn_context,
 	    }
 	}
 #ifdef GSS_USE_CCACHE_STORE
-	if (text->ccname) {
-            params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS;
-	}
+        /* TODO: This should maybe depend on "pass_credentials" (server-side), or Kerberos token attributes */
+        params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS;
 #endif
 	if (params->props.security_flags & SASL_SEC_PASS_CREDENTIALS) {
 	    req_flags = req_flags |  GSS_C_DELEG_FLAG;

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -2046,7 +2046,7 @@ static int gssapi_client_mech_step(void *conn_context,
 		
 		return SASL_INTERACT;
 	    }
-        }
+	}
 	    
 	if (text->server_name == GSS_C_NO_NAME) { /* only once */
 	    if (params->serverFQDN == NULL

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1412,13 +1412,12 @@ gssapi_server_mech_authneg(context_t *text,
                                                     name_token.value, ccache);
             if (NULL == text->ccname) {
                 params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
-                                   "GSSAPI server could not store credentials cache %s for %s",
-                                   ccache, name_token.value);
+                                   "GSSAPI server could not store credentials cache %s", ccache);
                 /* Non breaking error, users will just not be able to authenticate to underlying services */
             }
             else {
                 params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
-                                   "GSSAPI server saved credentials cache %s for %s", ccache, name_token.value);
+                                   "GSSAPI server saved credentials cache %s", ccache);
             }
         }
     }

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -88,6 +88,14 @@
 #include <errno.h>
 #include <assert.h>
 
+#ifdef GSS_USE_CC
+#include <sys/stat.h>
+#ifdef HAVE_GETPWNAM
+#include <pwd.h>
+#include <sys/types.h>
+#endif
+#endif
+
 /*****************************  Common Section  *****************************/
 
 static const char * GSSAPI_BLANK_STRING = "";
@@ -198,6 +206,9 @@ typedef struct context {
     char *authid; /* hold the authid between steps - server */
     const char *user;   /* hold the userid between steps - client */
     void *ctx_mutex; /* A per-context mutex */
+#ifdef GSS_USE_CC
+    const char* ccname;
+#endif
 } context_t;
 
 enum {
@@ -581,7 +592,14 @@ static int sasl_gss_free_context_contents(context_t *text)
 	(void) gss_release_name(&min_stat,&text->server_name);
 	text->server_name = GSS_C_NO_NAME;
     }
-    
+
+#ifdef GSS_USE_CC
+    if (text->ccname) {
+      free(text->ccname);
+      text->ccname = NULL;
+    }
+#endif
+
     if ( text->server_creds != GSS_C_NO_CREDENTIAL) {
 	(void) gss_release_cred(&min_stat, &text->server_creds);
 	text->server_creds = GSS_C_NO_CREDENTIAL;
@@ -811,6 +829,229 @@ gssapi_server_mech_new(void *glob_context,
     return SASL_OK;
 }
 
+#ifdef GSS_USE_CC
+static char* strsubst(context_t* text, const char* haystack, const char* needle, const char* subst) {
+  const size_t haystack_len = strlen(haystack);
+  const size_t needle_len = strlen(needle);
+  const size_t subst_len = strlen(subst);
+  const size_t dest_len = haystack_len - needle_len + subst_len;
+  const char* needle_ptr = strstr(haystack, needle);
+  const size_t pre_needle_len = needle_ptr - haystack;
+  char* d;
+
+  if ((NULL == haystack) || (NULL == needle) || (NULL == subst)) {
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                          "GSSAPI error: Bad ccache format");
+    return NULL;
+  }
+
+  if (NULL == (d = malloc(dest_len + 1))) {
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                          "GSSAPI error: Out of memory processing ccache");
+    return NULL;
+  }
+
+  strncpy(d, haystack, pre_needle_len);
+  d[pre_needle_len] = 0;
+  strcat(d, subst);
+  strcat(d, &haystack[pre_needle_len + needle_len]);
+
+  return d;
+}
+
+static char* create_krb5_ccache(context_t* text, const char* username, const char* ccache) {
+  char* ccname = NULL;
+  char* ccache_copy = NULL;
+  char* needle;
+
+  if (NULL == ccache) {
+    goto noccache;
+  }
+
+  /* Empty string will result in default value */
+  if (0 == strcmp("", ccache)) {
+    goto noccache;
+  }
+
+  if (NULL == username) {
+    goto sanity_check_failed;
+  }
+
+  if (NULL == (ccache_copy = strdup(ccache))) {
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                          "GSSAPI error: out of memory");
+    goto malloc_failed;
+  }
+
+  while (NULL != (needle = strstr(ccache_copy, "%"))) {
+    if (NULL != ccname) {
+      /* Every iteration starts with a fresh destination string */
+      free(ccname);
+      ccname = NULL;
+    }
+
+    switch (needle[1]) {
+    case 'u': {
+#ifdef HAVE_GETPWNAM
+      char uid_str[100];
+      struct passwd* pwd = getpwnam(username);
+      sprintf(uid_str, "%d", pwd->pw_uid);
+      if (NULL == (ccname = strsubst(text, ccache_copy, "%u", uid_str))) {
+        goto parsing_failed;
+      }
+#else
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: %u is supported in ccache");
+      goto parsing_failed;
+#endif
+      break;
+    }
+    case 'U': {
+      ccname = strsubst(text, ccache_copy, "%U", username);
+      break;
+    }
+    case 'e': {
+#ifdef HAVE_GETEUID
+      char euid_str[100];
+      uid_t euid = geteuid();
+      sprintf(euid_str, "%ul", euid);
+      if (NULL == (ccname = strsubst(text, ccache_copy, "%e", euid_str))) {
+        goto parsing_failed;
+      }
+#else
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: %%e is supported in ccache");
+      goto parsing_failed;
+#endif
+      break;
+    }
+    case 'E': {
+#ifdef HAVE_GETLOGIN_R
+      char server_username[100];
+      getlogin_r(server_username, sizeof(server_username));
+      if (NULL == (ccname = strsubst(text, ccache_copy, "%E", server_username))) {
+        goto parsing_failed;
+      }
+#else
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: %%E is supported in ccache");
+      goto parsing_failed;
+#endif
+      break;
+    }
+    case 'p': {
+#ifdef HAVE_GETPID
+      char pid_str[100];
+      pid_t pid;
+      pid = getpid();
+      sprintf(pid_str, "%d", pid);
+      if (NULL == (ccname = strsubst(text, ccache_copy, "%p", pid_str))) {
+        goto parsing_failed;
+      }
+#else
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: %%p is supported in ccache");
+      goto parsing_failed;
+#endif
+      break;
+    }
+    default:
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: invalid ccache format");
+      goto invalid_ccache_format;
+      break;
+    }
+
+    free(ccache_copy);
+    if (NULL != ccname) {
+      ccache_copy = strdup(ccname);
+      if (NULL == ccache_copy) {
+        text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                              "GSSAPI error: out of memory");
+        goto malloc_failed;
+      }
+    }
+  }
+
+  if ((NULL == ccname) && (NULL != ccache)) {
+    if (NULL == (ccname = strdup(ccache))) {
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: out of memory");
+      goto malloc_failed;
+    }
+  }
+
+  goto ok;
+ invalid_ccache_format:
+ malloc_failed:
+ sanity_check_failed:
+ parsing_failed:
+  if (NULL != ccname) {
+    free(ccname);
+    ccname = NULL;
+  }
+ noccache:
+  if (NULL == ccname) {
+    ccname = strdup(getenv("KRB5CCNAME"));
+    if (NULL == ccname) {
+      text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                            "GSSAPI error: out of memory");
+    }
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+                          "GSSAPI warning: using KRB5CCNAME for ccache");
+  }
+ ok:
+  if (NULL != ccache_copy) {
+    free(ccache_copy);
+  }
+  return ccname;
+}
+
+static char *store_client_credentials(context_t* text, gss_cred_id_t* client_credentials, const char* username, const char* ccache) {
+  gss_key_value_element_desc element;
+  gss_key_value_set_desc store;
+  char* ccname = NULL;
+  OM_uint32 maj_stat;
+  OM_uint32 min_stat;
+
+  if (NULL == (ccname = create_krb5_ccache(text, username, ccache))) {
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+			  "GSSAPI error: unable to generate krb5cc filename");
+    goto create_krb5_ccache_failed;
+  }
+
+  element.key = "ccache";
+  element.value = ccname;
+  store.elements = &element;
+  store.count = 1;
+
+  maj_stat = gss_store_cred_into(&min_stat,
+                                 *client_credentials,
+                                 GSS_C_INITIATE,
+                                 GSS_C_NULL_OID,
+                                 1,
+                                 1,
+                                 &store,
+                                 NULL,
+                                 NULL);
+
+  if (GSS_S_COMPLETE != maj_stat) {
+    text->utils->seterror(text->utils->conn, SASL_LOG_ERR,
+			  "GSSAPI error: unable to store credentials in krb5cc file");
+    goto gss_store_cred_into_failed;
+  }
+
+  goto ok;
+
+ gss_store_cred_into_failed:
+  free(ccname);
+  ccname = NULL;
+ create_krb5_ccache_failed:
+ ok:
+  return ccname;
+}
+#endif
+
 static int 
 gssapi_server_mech_authneg(context_t *text,
 			   sasl_server_params_t *params,
@@ -877,15 +1118,48 @@ gssapi_server_mech_authneg(context_t *text,
 
 	/* If caller didn't provide creds already */
 	if ( server_creds == GSS_C_NO_CREDENTIAL) {
+#ifdef GSS_USE_LOAD_FROM
+            const sasl_utils_t *utils = text->utils;
+            unsigned int rl; /* Required storage by getopt() */
+            char* keytab = NULL; /* The configured credentials cache file path */
+            utils->getopt(utils->getopt_context, "GSSAPI", "keytab", (const char**)&keytab, &rl);
+#endif
 	    GSS_LOCK_MUTEX_CTX(params->utils, text);
-	    maj_stat = gss_acquire_cred(&min_stat, 
-					text->server_name,
-					GSS_C_INDEFINITE, 
-					GSS_C_NO_OID_SET,
-					GSS_C_ACCEPT,
-					&text->server_creds, 
-					NULL, 
-					NULL);
+#ifdef GSS_USE_LOAD_FROM
+            if (keytab != NULL) { /* Force cached credentials to use GSS Proxy compliant API of GSS */
+                gss_key_value_element_desc ccache_element = {.key = "ccache", .value = NULL};
+                gss_key_value_element_desc keytab_element = {.key = "keytab", .value = keytab};
+                gss_key_value_element_desc elements[2];
+                gss_key_value_set_desc cred_store = {.elements = &ccache_element, .count = 1};
+
+                elements[0] = ccache_element;
+                elements[1] = keytab_element;
+                cred_store.count = 2;
+		cred_store.elements = elements;
+
+                maj_stat = gss_acquire_cred_from(&min_stat,
+                                                 text->server_name,
+                                                 GSS_C_INDEFINITE,
+                                                 GSS_C_NO_OID_SET,
+                                                 GSS_C_ACCEPT,
+                                                 &cred_store,
+                                                 &text->server_creds,
+                                                 NULL,
+                                                 NULL);
+            }
+            else {
+#endif
+                maj_stat = gss_acquire_cred(&min_stat,
+                                            text->server_name,
+                                            GSS_C_INDEFINITE,
+                                            GSS_C_NO_OID_SET,
+                                            GSS_C_ACCEPT,
+                                            &text->server_creds, 
+                                            NULL,
+                                            NULL);
+#ifdef GSS_USE_LOAD_FROM
+            }
+#endif
 	    GSS_UNLOCK_MUTEX_CTX(params->utils, text);
 
 	    if (GSS_ERROR(maj_stat)) {
@@ -982,7 +1256,11 @@ gssapi_server_mech_authneg(context_t *text,
     } else {
 	text->qop = LAYER_NONE | LAYER_INTEGRITY | LAYER_CONFIDENTIALITY;
     }
-
+#ifdef GSS_USE_CC
+    if (text->ccname) {
+        params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS; /* Force delegation flag */
+    }
+#endif
     if ((params->props.security_flags & SASL_SEC_PASS_CREDENTIALS) &&
 	(!(out_flags & GSS_C_DELEG_FLAG) ||
 	 text->client_creds == GSS_C_NO_CREDENTIAL) ) 
@@ -1092,6 +1370,23 @@ gssapi_server_mech_authneg(context_t *text,
 	ret = SASL_NOMEM;
 	goto cleanup;
     }
+
+#ifdef GSS_USE_CC
+    /* Get ccache from sasl-config file if located elsewhere than /tmp */
+    if (GSS_C_NO_CREDENTIAL != text->client_creds) {
+        const char* ccache = NULL;
+        const sasl_utils_t *utils = text->utils;
+        unsigned int rl;
+        utils->getopt(utils->getopt_context, "GSSAPI", "ccache", (const char**)&ccache, &rl);
+        if (NULL == ccache) {
+            text->ccname = NULL;
+        }
+        else {
+            text->ccname = (const char*)store_client_credentials(text, &(text->client_creds),
+                                                                 name_token.value, ccache);
+        }
+    }
+#endif
 
     if (text->http_mode) {
 	/* HTTP doesn't do any ssf negotiation */
@@ -1772,7 +2067,11 @@ static int gssapi_client_mech_step(void *conn_context,
 		req_flags |= GSS_C_CONF_FLAG;
 	    }
 	}
-
+#ifdef GSS_USE_CC
+	if (text->ccname) {
+            params->props.security_flags |= SASL_SEC_PASS_CREDENTIALS; /* Force delegation */
+	}
+#endif
 	if (params->props.security_flags & SASL_SEC_PASS_CREDENTIALS) {
 	    req_flags = req_flags |  GSS_C_DELEG_FLAG;
 	}


### PR DESCRIPTION
This feature enables CyrusSASL to forward/delegate GSSAPI Kerberos cached credentials for authenticating to other services on the server-side, as suggested in Issue #585. It also optionally implements service keytab loading with gss_acquire_creds_from() to enable privilege separation using e.g. GSSProxy on a POSIX server.

The feature is implemented on behalf of Vricon Systems AB