### PR TITLE
Fix a bug which prevented the client from retrieving a credential from CCACHE.

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1777,7 +1777,17 @@ static int gssapi_client_mech_step(void *conn_context,
 	    req_flags = req_flags |  GSS_C_DELEG_FLAG;
 	}
 
-	/* If caller didn't provide creds already */
+	/*
+	 * If caller didn't provide creds already.
+	 *
+	 * In the case of Kerberos, a client typically wants to use
+	 * a credential in either a keytab file or the credentials cache
+	 * of the current process context.  This code path will try to
+	 * find a credential in the specified keytab file,  then the
+	 * credentials cache.  The keytab file can be specified by
+	 * "keytab" option, and it is configured by using
+	 * gsskrb5_register_acceptor_identity() API when available.
+	 */
 	if (client_creds == GSS_C_NO_CREDENTIAL) {
 	    GSS_LOCK_MUTEX_CTX(params->utils, text);
 	    maj_stat = gss_acquire_cred(&min_stat,
@@ -1790,14 +1800,16 @@ static int gssapi_client_mech_step(void *conn_context,
 					NULL);
 	    GSS_UNLOCK_MUTEX_CTX(params->utils, text);
 
-	    if (GSS_ERROR(maj_stat)) {
-		sasl_gss_seterror(text->utils, maj_stat, min_stat);
-		sasl_gss_free_context_contents(text);
-		return SASL_FAIL;
+	    /*
+	     * Ignore the error intentionally.  The credential was
+	     * not found in the specified keytab file.
+	     */
+	    if (GSS_ERROR(maj_stat) == 0) {
+		client_creds = text->client_creds;
 	    }
-	    client_creds = text->client_creds;
 	}
 
+	/* Try the credentials cache. */
 	GSS_LOCK_MUTEX_CTX(params->utils, text);
 	maj_stat = gss_init_sec_context(&min_stat,
 					client_creds, /* GSS_C_NO_CREDENTIAL */


### PR DESCRIPTION
Changes in the pull request #575 introduced a bug which prevented the SASL client from retrieving a credential from the credentials cache, while the intended behavior is that the client looks for the credential in the specified keytab file, then if not found, looks into the credentials cache.  This patch fixes the wrong behavior.