### PR TITLE
Revert the change to acquire init credentials

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -1777,27 +1777,6 @@ static int gssapi_client_mech_step(void *conn_context,
 	    req_flags = req_flags |  GSS_C_DELEG_FLAG;
 	}
 
-	/* If caller didn't provide creds already */
-	if (client_creds == GSS_C_NO_CREDENTIAL) {
-	    GSS_LOCK_MUTEX_CTX(params->utils, text);
-	    maj_stat = gss_acquire_cred(&min_stat,
-					text->server_name,
-					GSS_C_INDEFINITE,
-					GSS_C_NO_OID_SET,
-					GSS_C_INITIATE,
-					&text->client_creds, 
-					NULL, 
-					NULL);
-	    GSS_UNLOCK_MUTEX_CTX(params->utils, text);
-
-	    if (GSS_ERROR(maj_stat)) {
-		sasl_gss_seterror(text->utils, maj_stat, min_stat);
-		sasl_gss_free_context_contents(text);
-		return SASL_FAIL;
-	    }
-	    client_creds = text->client_creds;
-	}
-
 	GSS_LOCK_MUTEX_CTX(params->utils, text);
 	maj_stat = gss_init_sec_context(&min_stat,
 					client_creds, /* GSS_C_NO_CREDENTIAL */

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -2248,55 +2248,16 @@ static sasl_client_plug_t gssapi_client_plugins[] =
 #endif
 };
 
-int gssapiv2_client_plug_init(
-#ifndef HAVE_GSSKRB5_REGISTER_ACCEPTOR_IDENTITY
-    const sasl_utils_t *utils __attribute__((unused)),
-#else
-    const sasl_utils_t *utils,
-#endif
+int gssapiv2_client_plug_init(const sasl_utils_t *utils __attribute__((unused)), 
 			      int maxversion,
 			      int *out_version, 
 			      sasl_client_plug_t **pluglist,
 			      int *plugcount)
 {
-#ifdef HAVE_GSSKRB5_REGISTER_ACCEPTOR_IDENTITY
-    const char *keytab = NULL;
-    char keytab_path[1024];
-    unsigned int rl;
-#endif
-
     if (maxversion < SASL_CLIENT_PLUG_VERSION) {
 	SETERROR(utils, "Version mismatch in GSSAPI");
 	return SASL_BADVERS;
     }
-
-#ifdef HAVE_GSSKRB5_REGISTER_ACCEPTOR_IDENTITY
-    /* unfortunately, we don't check for readability of keytab if it's
-       the standard one, since we don't know where it is */
-    
-    /* FIXME: This code is broken */
-    
-    utils->getopt(utils->getopt_context, "GSSAPI", "keytab", &keytab, &rl);
-    if (keytab != NULL) {
-	if (access(keytab, R_OK) != 0) {
-	    utils->log(NULL, SASL_LOG_ERR,
-		       "Could not find keytab file: %s: %m", keytab);
-	    return SASL_FAIL;
-	}
-	
-	if(strlen(keytab) > sizeof(keytab_path)) {
-	    utils->log(NULL, SASL_LOG_ERR,
-		       "path to keytab is > %zu characters",
-		       sizeof(keytab_path));
-	    return SASL_BUFOVER;
-	}
-	
-	strncpy(keytab_path, keytab, sizeof(keytab_path));
-	keytab_path[sizeof(keytab_path) - 1] = '\0';
-	
-	gsskrb5_register_acceptor_identity(keytab_path);
-    }
-#endif
     
     *out_version = SASL_CLIENT_PLUG_VERSION;
     *pluglist = gssapi_client_plugins;


### PR DESCRIPTION
Hello, I think the change to call gss_acquire_cred() in the client code, is not correct.

Commit 238380260fe623212c0f21d63e763b7a849540d1 broke GSSAPI kerberos authentication, and commit 74faca7400f414784b5e2e136668e6f4ef0d6b96 "fixed" it by ignoring the error (which in my opinion will always occur, as below).

First, calling gss_acquire_cred() to acquire initiator client credentials and passing 'text->server_name' as client desired_name would never make sense, unless the only use case is when the client and server are the same principal, i think this can never work.

Secondly, gsskrb5_register_acceptor_identity() is for acceptor keytab, it is not for initiator, if it makes any impact then it may be a bug.
Instead, you can just use 'default_client_keytab_name' which is supported on modern MIT and and Heimdal, and then you don't need this change.
If you really want to control which keytab to use from code, you can use gss_acquire_cred_from() from the "credential store" API, which is also supported on both MIT and Heimdal implementations.