### PR TITLE
Use proper length for Fully Qualified Domain Names

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1442,11 +1442,6 @@ struct sockaddr_storage {
 #define NI_NUMERICSERV  8
 #endif
 
-/* Defined in RFC 1035. max strlen is only 253 due to length bytes. */
-#ifndef MAXHOSTNAMELEN
-#define        MAXHOSTNAMELEN  255
-#endif
-
 #ifndef HAVE_SYSEXITS_H
 #include "exits.h"
 #else

--- a/lib/client.c
+++ b/lib/client.c
@@ -398,7 +398,7 @@ int sasl_client_new(const char *service,
 		    sasl_conn_t **pconn)
 {
   int result;
-  char name[MAXHOSTNAMELEN];
+  char name[MAXFQDNLEN];
   sasl_client_conn_t *conn;
   sasl_utils_t *utils;
   sasl_getopt_t *getopt;
@@ -512,7 +512,7 @@ int sasl_client_new(const char *service,
   
   /* get the clientFQDN (serverFQDN was set in _sasl_conn_init) */
   memset(name, 0, sizeof(name));
-  if (get_fqhostname (name, MAXHOSTNAMELEN, 0) != 0) {
+  if (get_fqhostname (name, MAXFQDNLEN, 0) != 0) {
       return (SASL_FAIL);
   }
 

--- a/lib/common.c
+++ b/lib/common.c
@@ -773,9 +773,9 @@ int _sasl_conn_init(sasl_conn_t *conn,
       sasl_strlower (conn->serverFQDN);
   } else if (conn->type == SASL_CONN_SERVER) {
       /* We can fake it because we *are* the server */
-      char name[MAXHOSTNAMELEN];
+      char name[MAXFQDNLEN];
       memset(name, 0, sizeof(name));
-      if (get_fqhostname (name, MAXHOSTNAMELEN, 0) != 0) {
+      if (get_fqhostname (name, MAXFQDNLEN, 0) != 0) {
         return (SASL_FAIL);
       }
       

--- a/lib/saslint.h
+++ b/lib/saslint.h
@@ -112,6 +112,10 @@
 #define PATHS_DELIMITER	':'
 #endif
 
+/* A FQDN max len is 255 per RFC 1035,
+ * this means 253 chars max, we add one more for zero terminator */
+#define MAXFQDNLEN 254
+
 /* Datatype Definitions */
 typedef struct {
   const sasl_callback_t *callbacks;

--- a/mac/CommonKClient/mac_kclient3/Headers/Kerberos5/win-mac.h
+++ b/mac/CommonKClient/mac_kclient3/Headers/Kerberos5/win-mac.h
@@ -99,7 +99,6 @@ typedef unsigned short	u_short;
 typedef unsigned char	u_char;
 #endif /* KRB5_SYSTYPES__ */
 
-#define MAXHOSTNAMELEN  512
 #ifndef MAXPATHLEN
 #define MAXPATHLEN      256            /* Also for Windows temp files */
 #endif

--- a/saslauthd/auth_sasldb.c
+++ b/saslauthd/auth_sasldb.c
@@ -48,6 +48,7 @@
 #include "../include/sasl.h"
 #include "../include/saslplug.h"
 #include "../sasldb/sasldb.h"
+#include "../saslint.h"
 
 static int
 vf(void *context __attribute__((unused)),
@@ -138,7 +139,7 @@ auth_sasldb (
     int ret;
     size_t outsize;
     const char *use_realm;
-    char realm_buf[MAXHOSTNAMELEN];
+    char realm_buf[MAXFQDNLEN];
     /* END VARIABLES */
 
     init_lame_utils(&utils);
@@ -146,7 +147,7 @@ auth_sasldb (
     _sasl_check_db(&utils, (void *)0x1);
 
     if(!realm || !strlen(realm)) {
-	ret = gethostname(realm_buf,MAXHOSTNAMELEN);
+	ret = gethostname(realm_buf,MAXFQDNLEN);
 	if(ret) RETURN("NO");
 	use_realm = realm_buf;
     } else {


### PR DESCRIPTION
Per RFC 1035 the maximum FQDN is 253 chars, and not MAXHOSTNAMELEN which
varies between 64 and 1024 bytes depending on the system used.

Define and use a new variable.
Also fix get_fqhostname() to insure that the name returned is zero
terminated.

Fixes #583 