### PR TITLE
Allow GSS-SPNEGO to negotiate a ssf of 0

### DIFF
--- a/m4/sasl2.m4
+++ b/m4/sasl2.m4
@@ -289,6 +289,19 @@ if test "$gssapi" != no; then
 
   cmu_save_LIBS="$LIBS"
   LIBS="$LIBS $GSSAPIBASE_LIBS"
+  if test "$ac_cv_header_gssapi_gssapi_krb5_h" = "yes"; then
+    AC_CHECK_DECL(GSS_KRB5_CRED_NO_CI_FLAGS_X,
+                  [AC_DEFINE(HAVE_GSS_KRB5_CRED_NO_CI_FLAGS_X,1,
+                             [Define if your GSSAPI implementation supports GSS_KRB5_CRED_NO_CI_FLAGS_X])],,
+                  [
+                    AC_INCLUDES_DEFAULT
+                    #include <gssapi/gssapi_krb5.h>
+                    ])
+  fi
+  LIBS="$cmu_save_LIBS"
+
+  cmu_save_LIBS="$LIBS"
+  LIBS="$LIBS $GSSAPIBASE_LIBS"
   AC_CHECK_FUNCS(gss_get_name_attribute)
   LIBS="$cmu_save_LIBS"
 

--- a/tests/t_common.c
+++ b/tests/t_common.c
@@ -23,20 +23,21 @@ void send_string(int sd, const char *s, unsigned int l)
     if (ret != l) s_error("send data", ret, l, errno);
 }
 
-void recv_string(int sd, char *buf, unsigned int *buflen)
+void recv_string(int sd, char *buf, unsigned int *buflen, bool allow_eof)
 {
+    unsigned int bufsize = *buflen;
     unsigned int l;
     ssize_t ret;
 
+    *buflen = 0;
+
     ret = recv(sd, &l, sizeof(l), MSG_WAITALL);
+    if (allow_eof && ret == 0) return;
     if (ret != sizeof(l)) s_error("recv size", ret, sizeof(l), errno);
 
-    if (l == 0) {
-        *buflen = 0;
-        return;
-    }
+    if (l == 0) return;
 
-    if (*buflen < l) s_error("recv len", l, *buflen, E2BIG);
+    if (bufsize < l) s_error("recv len", l, bufsize, E2BIG);
 
     ret = recv(sd, buf, l, 0);
     if (ret != l) s_error("recv data", ret, l, errno);

--- a/tests/t_common.h
+++ b/tests/t_common.h
@@ -4,6 +4,7 @@
 #include "config.h"
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <sys/socket.h>
 
@@ -12,7 +13,7 @@
 
 void s_error(const char *hdr, ssize_t ret, ssize_t len, int err);
 void send_string(int sd, const char *s, unsigned int l);
-void recv_string(int sd, char *buf, unsigned int *buflen);
+void recv_string(int sd, char *buf, unsigned int *buflen, bool allow_eof);
 void saslerr(int why, const char *what);
 int getpath(void *context __attribute__((unused)), const char **path);
 void parse_cb(sasl_channel_binding_t *cb, char *buf, unsigned max, char *in);


### PR DESCRIPTION
In GSS-SPNEGO ssf negotiation is implicit and depends on GSSAPI level Integrity and Confidentiality flags.
In order to interoperate with Windows, which does not allow nested security layers, we need to be able to set ssf to 0 when GSS-SPNEGO is negotiated within an outer TLS channel.
Unfortunately MIT's GSSAPI always forces negotiation of Integrity and Confidentiality regardles of what flags are passed to gss_init_sec_context()
Add code to allow MIT to skip setting those flags on the wire as Windows interprets those as a *request* rather than an offer like MIT does.