### PR TITLE
Auth httpasswd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -551,6 +551,14 @@ if test "$httpform" != no; then
   AC_DEFINE(HAVE_HTTPFORM,[],[Include HTTP form Support])
 fi
 
+AC_ARG_ENABLE(htpasswd, [  --enable-htpasswd       enable htpasswd file authentication [[no]] ],
+  htpasswd=$enableval,
+  htpasswd=no)
+if test "htpasswd" != no; then
+  AC_DEFINE(HAVE_HTPASSWD,[],[Include htpasswd file support])
+fi
+AM_CONDITIONAL(AUTH_HTPASSWD, test "$htpasswd" != no)
+
 AC_ARG_WITH(pam, AC_HELP_STRING([--with-pam=DIR], [use PAM (rooted in DIR) [yes]]),,
 	with_pam=yes)
 if test "$with_pam" != no; then

--- a/doc/htpasswd.md
+++ b/doc/htpasswd.md
@@ -1,0 +1,44 @@
+Here are information about auth htpasswd. 
+## Build
+To build this extension you have to install apr library:
+```shell script
+apt-get install libaprutil1-dev
+``` 
+and enable it with configure script:
+```shell script
+./configure --enable-htpasswd
+```
+the do the rest:
+```shell script
+make 
+make install
+```
+when everything is done correct `./saslauthd` will output:
+```
+authentication mechanisms: getpwent rimap shadow htpasswd
+```
+
+## Usage/configuration
+Only thing to needs to be configured is the location of htpasswd file
+and it is passed with `-O` option:
+```shell script
+saslauthd -a htpasswd O /path/to/htpasswd
+```
+
+## Test it
+Create htpasswd file (it requires `apache2-utils`):
+```shell script
+htpasswd -bc .htpasswd test1 password1
+```
+Run in debug mode (only for testing)
+```shell script
+sudo saslauthd -d -a htpasswd O .htpasswd
+```
+
+Test with `testsaslauthd`:
+```shell script
+testsaslauthd -u test1 -p password1
+```
+
+If there is any problem with auth method additional logs
+can be found is `auth.log`.

--- a/saslauthd/Makefile.am
+++ b/saslauthd/Makefile.am
@@ -10,22 +10,28 @@ LIBSASLDB_OBJS = $(top_builddir)/sasldb/libsasldb.la
 else
 LIBSASLDB_OBJS =
 endif
+if AUTH_HTPASSWD
+LIBAPR_OBJ     = -lapr-1 -laprutil-1
+else
+LIBAPR_OBJ     =
+endif
 
 saslauthd_SOURCES = mechanisms.c globals.h \
 		    mechanisms.h auth_dce.c auth_dce.h auth_getpwent.c \
 		    auth_getpwent.h auth_krb5.c auth_krb5.h auth_krb4.c \
-		    auth_krb4.h auth_pam.c auth_pam.h auth_rimap.c auth_httpform.c \
-		    auth_rimap.h auth_shadow.c auth_shadow.h auth_sia.c auth_httpform.h \
+		    auth_krb4.h auth_pam.c auth_pam.h auth_rimap.c auth_httpform.c auth_htpasswd.c \
+		    auth_rimap.h auth_shadow.c auth_shadow.h auth_sia.c auth_httpform.h auth_htpasswd.h \
 		    auth_sia.h auth_sasldb.c auth_sasldb.h lak.c lak.h \
 		    auth_ldap.c auth_ldap.h cache.c cache.h cfile.c cfile.h \
 		    krbtf.c krbtf.h utils.c utils.h \
-                    ipc_unix.c ipc_doors.c saslauthd-main.c saslauthd-main.h \
+            ipc_unix.c ipc_doors.c saslauthd-main.c saslauthd-main.h \
 		    md5.c saslauthd_md5.h
 EXTRA_saslauthd_sources = getaddrinfo.c getnameinfo.c
 saslauthd_DEPENDENCIES = saslauthd-main.o $(LTLIBOBJS_FULL)
 saslauthd_LDADD	= @SASL_KRB_LIB@ \
 		  @GSSAPIBASE_LIBS@ @LIB_CRYPT@ @LIB_SIA@ \
-		  @LIB_SOCKET@ @SASL_DB_LIB@ @LIB_PAM@ @LDAP_LIBS@ $(LTLIBOBJS_FULL) $(CRYPTO_COMPAT_OBJS) $(LIBSASLDB_OBJS)
+		  @LIB_SOCKET@ @SASL_DB_LIB@ @LIB_PAM@ @LDAP_LIBS@ $(LTLIBOBJS_FULL) \
+		  $(CRYPTO_COMPAT_OBJS) $(LIBSASLDB_OBJS) $(LIBAPR_OBJ)
 
 testsaslauthd_SOURCES = testsaslauthd.c utils.c
 testsaslauthd_LDADD = @LIB_SOCKET@

--- a/saslauthd/auth_htpasswd.c
+++ b/saslauthd/auth_htpasswd.c
@@ -1,0 +1,180 @@
+
+/* MODULE: auth_htpasswd */
+
+/* COPYRIGHT
+ * Copyright (c) 2020 Ryszard Trojnacki.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain any existing copyright
+ *    notice, and this entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 2. Redistributions in binary form must reproduce all prior and current
+ *    copyright notices, this list of conditions, and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ * END COPYRIGHT */
+
+/* PUBLIC DEPENDENCIES */
+#include "mechanisms.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <pwd.h>
+#include <config.h>
+#include <unistd.h>
+#include <apr-1.0/apr_strings.h>
+#include <apr-1.0/apr_md5.h>            /* for apr_password_validate */
+#include <apr-1.0/apr_file_io.h>
+#include <apr-1.0/apr_lib.h>
+
+/* END PUBLIC DEPENDENCIES */
+
+# include "globals.h"
+
+#define RETURN(x) return strdup(x)
+
+static apr_pool_t* pool;
+
+#define MAX_STRING_LEN  8192        /* from httpd.h */
+
+/* FUNCTION: auth_httpform_init */
+
+/* SYNOPSIS
+ * Validate the host and service names for the remote server.
+ * END SYNOPSIS */
+
+int
+auth_htpasswd_init (
+) {
+    if(apr_initialize()!= APR_SUCCESS) {
+        return -1;
+    }
+    apr_pool_initialize();
+    if(apr_pool_create(&pool, NULL)!= APR_SUCCESS) {
+        return -2;
+    }
+    return 0;
+}
+
+/* END FUNCTION: auth_httpform_init */
+
+
+/* FUNCTION: auth_htpasswd */
+
+char *					/* R: allocated response string */
+auth_htpasswd (
+        /* PARAMETERS */
+#ifdef AUTH_HTPASSWD
+        const char *login,			/* I: plaintext authenticator */
+        const char *password,			/* I: plaintext password */
+        const char *service __attribute__((unused)),
+        const char *realm __attribute__((unused)),
+#else
+        const char *login __attribute__((unused)),/* I: plaintext authenticator */
+        const char *password __attribute__((unused)),  /* I: plaintext password */
+        const char *service __attribute__((unused)),
+        const char *realm __attribute__((unused)),
+#endif
+        const char *remote __attribute__((unused)) /* I: remote host address */
+        /* END PARAMETERS */
+)
+{
+#ifdef AUTH_HTPASSWD
+    /* VARIABLES */
+    apr_file_t *fpw = NULL;
+    char line[MAX_STRING_LEN];
+    char *scratch, cp[MAX_STRING_LEN];
+
+    int ret=-10;
+    /* END VARIABLES */
+
+    if(!mech_option) RETURN("NO");
+
+    if (apr_file_open(&fpw, mech_option, APR_READ | APR_BUFFERED, APR_OS_DEFAULT, pool) != APR_SUCCESS) {
+        RETURN("NO");   /* error opening htpasswd file*/
+    }
+    while (apr_file_gets(line, sizeof(line), fpw) == APR_SUCCESS) {
+        char *colon;
+
+        strcpy(cp, line);
+        scratch = cp;
+        while (apr_isspace(*scratch)) {
+            ++scratch;
+        }
+
+        if (!*scratch || (*scratch == '#')) {
+            continue;
+        }
+        /*
+         * See if this is our user.
+         */
+        colon = strchr(scratch, ':');
+        if (colon != NULL) {
+            *colon = '\0';
+        }
+        else {
+            /*
+             * If we've not got a colon on the line, this could well
+             * not be a valid htpasswd file.
+             * We should bail at this point.
+             */
+            ret=-1;
+            break;
+        }
+        if (strcmp(login, scratch) == 0) {
+            /* We found the user we were looking for */
+            /* Verify */
+            char *hash = colon + 1;
+            size_t len;
+
+            len = strcspn(hash, "\r\n");
+            if (len == 0) {
+                /*apr_file_printf(errfile, "Empty hash for user %s" NL,
+                                user);*/
+                ret=-2;
+                break;
+            }
+            hash[len] = '\0';
+
+            if (apr_password_validate(password, hash) != APR_SUCCESS) {
+                ret=1;  /* invalid password */
+            } else {
+                ret=0;
+            }
+            break;
+        }
+    }
+    apr_file_close(fpw);
+
+    if(ret) RETURN("NO");
+
+    RETURN("OK");
+#else
+    RETURN("NO");
+#endif
+}
+
+/* END FUNCTION: auth_htpasswd */
+
+/* END MODULE: auth_htpasswd */

--- a/saslauthd/auth_htpasswd.h
+++ b/saslauthd/auth_htpasswd.h
@@ -1,0 +1,36 @@
+/* COPYRIGHT
+ * Copyright (c) 2020 Ryszard Trojnacki.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain any existing copyright
+ *    notice, and this entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 2. Redistributions in binary form must reproduce all prior and current
+ *    copyright notices, this list of conditions, and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ * END COPYRIGHT */
+
+char *auth_htpasswd(const char *, const char *, const char *, const char *, const char *);
+int auth_htpasswd_init(void);

--- a/saslauthd/mechanisms.c
+++ b/saslauthd/mechanisms.c
@@ -93,7 +93,7 @@ authmech_t mechanisms[] =
     {   "httpform",     auth_httpform_init,     auth_httpform },
 #endif /* AUTH_HTTPFORM */
 #ifdef AUTH_HTPASSWD
-    {   "htpasswd",     0,     auth_htpasswd },
+    {   "htpasswd",     auth_htpasswd_init,     auth_htpasswd },
 #endif /* AUTH_HTPASSWD */
     {	0,		0,			0 }
 };

--- a/saslauthd/mechanisms.c
+++ b/saslauthd/mechanisms.c
@@ -56,6 +56,9 @@
 #ifdef AUTH_HTTPFORM
 #include "auth_httpform.h"
 #endif
+#ifdef AUTH_HTPASSWD
+#include "auth_htpasswd.h"
+#endif
 /* END PUBLIC DEPENDENCIES */
 
 authmech_t mechanisms[] =
@@ -88,7 +91,10 @@ authmech_t mechanisms[] =
 #endif /* AUTH_LDAP */
 #ifdef AUTH_HTTPFORM
     {   "httpform",     auth_httpform_init,     auth_httpform },
-#endif /* AUTH_LDAP */
+#endif /* AUTH_HTTPFORM */
+#ifdef AUTH_HTPASSWD
+    {   "htpasswd",     0,     auth_htpasswd },
+#endif /* AUTH_HTPASSWD */
     {	0,		0,			0 }
 };
 

--- a/saslauthd/mechanisms.h
+++ b/saslauthd/mechanisms.h
@@ -95,4 +95,10 @@ extern authmech_t *authmech;		/* auth mech daemon is using */
 # endif
 #endif
 
+#ifndef AUTH_HTPASSWD
+# ifdef HAVE_HTPASSWD
+#  define AUTH_HTPASSWD
+# endif
+#endif
+
 #endif  /* _MECHANISMS_H */


### PR DESCRIPTION
I have added additional auth method - htpasswd which is working with Apache2 htpasswd files.
I have added this because a lot of software is working with those files (Nginx, Apache2 httpd, Buildbot, etc), and why cyrus-sals shouldn't be.