### PR TITLE
Increase MAX_REQ_LEN to allow transport of more sophisticated credent…

### DIFF
--- a/saslauthd/saslauthd-main.h
+++ b/saslauthd/saslauthd-main.h
@@ -82,7 +82,7 @@
 #define DOOR_FILE		"/mux"              
 
 /* login, pw, service, realm buffer size */
-#define MAX_REQ_LEN		256     
+#define MAX_REQ_LEN		65536
 
 /* socket backlog when supported */
 #define SOCKET_BACKLOG  	32


### PR DESCRIPTION
…ials

The constant MAX_REQ_LEN, which controls the maximum size of a password
accepted by saslauthd, is increased from 256 to 4096.  Though a simple
human-typed plaintext password is unlikely to ever be so big, this
allows saslauthd to accept other, larger credentials.  In particular,
this is large enough to allow saslauthd to receive SAML2 security
assertions and pass them through to a PAM authenticator for verification.

MAX_REQ_LEN also affects the fixed-size buffers allocated for "login",
"service", "realm", and "client_addr", though only "password" needs
to be enlarged for this use-case.  However, at this point it doesn't
seem to be worth the effort/complexity to introduce a separate constant
to independently control the size of the "password" buffer.