### PR TITLE
sample/: Fix build with clang and older gcc

### DIFF
--- a/sample/common.c
+++ b/sample/common.c
@@ -47,6 +47,8 @@
 
 #include <sasl.h>
 
+#include "common.h"
+
 /* send/recv library for IMAP4 style literals.
 
    really not important; just one way of doing length coded strings */

--- a/sample/common.h
+++ b/sample/common.h
@@ -43,6 +43,13 @@ extern int send_string(FILE *f, const char *s, int l);
 extern int recv_string(FILE *f, char *buf, int buflen);
 
 extern int debuglevel;
+
+/*
+ *  For gcc < 4.3 and clang, glibc will implement dprintf using a
+ *  macro.  To ensure we use our own implementation of dprintf
+ *  rather than glibc's, we need to undef dprintf here.
+ */
+#undef dprintf
 extern int dprintf(int lvl, const char *fmt, ...);
 
 extern void saslerr(int why, const char *what);


### PR DESCRIPTION
dprintf is defined as a preprocessor macro for these compilers, so we
need to undefine it before declaring our own version of dprintf.