### PR TITLE
Feature #319: support multiple ldap realms

### DIFF
--- a/saslauthd/auth_ldap.c
+++ b/saslauthd/auth_ldap.c
@@ -61,19 +61,20 @@ auth_ldap(
   /* END PARAMETERS */
   )
 {
-	static LAK *lak = NULL;
+	LAK *lak = NULL;
 	int rc = 0;
 
-	if (lak == NULL) {
-		rc = lak_init(SASLAUTHD_CONF_FILE, &lak);
-		if (rc != LAK_OK) {
-			lak = NULL;
-			RETURN("NO");
-		}
+	rc = lak_init(SASLAUTHD_CONF_FILE, &lak);
+	if (rc != LAK_OK) {
+		lak = NULL;
+		RETURN("NO");
 	}
 
 	rc = lak_authenticate(lak, login, service, realm, password);
-    	if (rc == LAK_OK) {
+
+	lak_close(lak);
+
+	if (rc == LAK_OK) {
 		RETURN("OK");
 	} else {
 		RETURN("NO");

--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -201,7 +201,8 @@ static int lak_config_read(
 			continue;
 
 		if (!strcasecmp(key, "realm")) {
-			/* ignore and skip */
+			/* take this as a default for ldap_realm, although it could be remapped */
+			strlcpy(conf->realm, p, LAK_BUF_LEN);
 		} else if (!strcasecmp(key, "ldap_servers"))
 			strlcpy(conf->servers, p, LAK_URL_LEN);
 

--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -1592,7 +1592,7 @@ int lak_authenticate(
 	if (EMPTY(realm))
 		realm = lak->conf->default_realm;
 
-	syslog(LOG_DEBUG|LOG_AUTH, "lak_authenticate for realm %s", realm);
+	syslog(LOG_DEBUG|LOG_AUTH, "lak_authenticate for realm %s, user %s", realm, user);
 	rc = lak_config_read(lak->conf, lak->conf->path, realm);
 	if (rc != LAK_OK) {
 		syslog(LOG_ERR|LOG_AUTH, "lak_authenticate error reading config for realm %s", realm);

--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -80,7 +80,7 @@ typedef struct lak_password_scheme {
 	void *rock;
 } LAK_PASSWORD_SCHEME;
 
-static int lak_config_read(LAK_CONF *, const char *);
+static int lak_config_read(LAK_CONF *, const char *, const char *);
 static int lak_config_int(const char *);
 static int lak_config_switch(const char *);
 static void lak_config_free(LAK_CONF *);
@@ -144,12 +144,14 @@ static const char *dn_attr = "dn";
 
 static int lak_config_read(
 	LAK_CONF *conf,
-	const char *configfile)
+	const char *configfile,
+	const char *configrealm)
 {
 	FILE *infile;
 	int lineno = 0;
 	char buf[4096];
 	char *p, *key;
+	int in_realm = 1; /* default for single realm configuration */
 
 	infile = fopen(configfile, "r");
 	if (!infile) {
@@ -189,7 +191,19 @@ static int lak_config_read(
 			return LAK_FAIL;
 		}
 
-		if (!strcasecmp(key, "ldap_servers"))
+		if (!strcasecmp(key, "realm")) {
+			if(!strcasecmp(p, configrealm)) {
+				in_realm = 1;
+			} else {
+				in_realm = 0;
+			}
+		}
+		if (!in_realm)
+			continue;
+
+		if (!strcasecmp(key, "realm")) {
+			/* ignore and skip */
+		} else if (!strcasecmp(key, "ldap_servers"))
 			strlcpy(conf->servers, p, LAK_URL_LEN);
 
 		else if (!strcasecmp(key, "ldap_bind_dn"))
@@ -402,7 +416,7 @@ static int lak_config(
 
 	strlcpy(conf->path, configfile, LAK_PATH_LEN);
 
-	rc = lak_config_read(conf, conf->path);
+	rc = lak_config_read(conf, conf->path, "");
 	if (rc != LAK_OK) {
 		lak_config_free(conf);
 		return rc;
@@ -1563,8 +1577,16 @@ int lak_authenticate(
 	if (EMPTY(user))
 		return LAK_FAIL;
 
-	if (EMPTY(realm))
+	if (EMPTY(realm)) {
 		realm = lak->conf->default_realm;
+	} else {
+		syslog(LOG_DEBUG|LOG_AUTH, "lak_authenticate for realm %s", realm);
+		rc = lak_config_read(lak->conf, lak->conf->path, realm);
+		if (rc != LAK_OK) {
+			syslog(LOG_ERR|LOG_AUTH, "lak_authenticate error reading config for realm %s", realm);
+			return LAK_FAIL;
+		}
+	}
 
 	for (i = 0; authenticator[i].method != -1; i++) {
 		if (authenticator[i].method == lak->conf->auth_method) {

--- a/saslauthd/lak.c
+++ b/saslauthd/lak.c
@@ -192,10 +192,9 @@ static int lak_config_read(
 		}
 
 		if (!strcasecmp(key, "realm")) {
+			in_realm = 0;
 			if(!strcasecmp(p, configrealm)) {
 				in_realm = 1;
-			} else {
-				in_realm = 0;
 			}
 		}
 		if (!in_realm)


### PR DESCRIPTION
Feature #319, cleanup of the original patch from John Newbigin

**Changes**:

- be able to handle several LDAP realm configurations within one daemon setup
- adds the keyword `realm` that can be used to delimit several sets of the standard parameters within the conf file into sections (one section associated with each realm) 

This avoids ugly workarounds in practical setups and allows to use saslauthd as a "proxy" for several **different** LDAP realms. NOTE that this differs from the multiple servers setup in the `ldap_servers` for redundancy/failover.

Another point is that there are different use cases you can get into the code. One is via `sasl_checkpasswd` API call without a realm and via the mutex and providing the realm (what I tested initially only and figured out openldap uses the API call instead). So during the code review some eye on how the realm is treated is needed as well.

CACHE:

* LAK cache via static variable removed, because the configuration is now dynamic / dependent on parameters. An alternative implementation could load all the settings in memory and store the realms in a table (not done).
* Is the auth cache still ok with the changes? The cache handling is also to be checked the realm shall always be part of the key for the cache. As far as I tested looks like it behaves correctly.

**KNOWN ISSUE**:

There seems to be an issue with the certificate verification in multiple realm mode. The child process seems to remember the TLS CA CERT file to use and uses randomly (depending on which worker process was selected) a wrong one. Not sure where this is persisted and how to remove it yet. Can be worked around by providing a global `ldap_tls_cacert_file` setting with all CA in it.