### PR TITLE
respect namelen in get_fqhostname

### DIFF
--- a/lib/saslutil.c
+++ b/lib/saslutil.c
@@ -525,8 +525,8 @@ int get_fqhostname(
     struct addrinfo hints;
     struct addrinfo *result;
 
-    return_value = gethostname (name, namelen -1);
-    name[namelen] = '\0'; /* insure string is always 0 terminated*/
+    return_value = gethostname (name, namelen);
+    name[namelen-1] = '\0'; /* insure string is always 0 terminated*/
     if (return_value != 0) {
 	return (return_value);
     }
@@ -577,6 +577,7 @@ int get_fqhostname(
     }
 
     strncpy (name, result->ai_canonname, namelen);
+    name[namelen-1] = '\0'; /* insure string is always 0 terminated*/
     freeaddrinfo (result);
 
 LOWERCASE:


### PR DESCRIPTION
The reason of the PR is memory corruption in get_fqhostname.
name[namelen] = '\0' is effectively out of bounds if namelen is sizeof, which is the case.
The issue introduced in cafd436fdb7bb79554b9564acf8345d21e25604d