### PR TITLE
common: Define the missing crypto_compat_version version.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -46,6 +46,7 @@
 # See <http://www.gnu.org/software/libtool/manual/libtool.html#Versioning>
 # CURRENT:REVISION:AGE
 plugin_common_version = 3:0:0
+crypto_compat_version = 0:0:0
 
 AM_CPPFLAGS=-fPIC -I$(top_srcdir)/include -I$(top_builddir)/include
 


### PR DESCRIPTION
This fixes the build with slibtool (https://git.foss21.org/slibtool) which is an alternative implementation for GNU libtool.
```
rdlibtool  --tag=CC   --mode=link clang  -Wall -W -g -O2 -version-info  -no-undefined  -o libcrypto_compat.la  crypto-compat.lo  -lresolv 
rdlibtool: error: option [--version-info] requires a value 
make[2]: *** [Makefile:481: libcrypto_compat.la] Error 2
make[2]: Leaving directory '/tmp/cyrus-sasl/common'
make[1]: *** [Makefile:677: all-recursive] Error 1
make[1]: Leaving directory '/tmp/cyrus-sasl'
make: *** [Makefile:545: all] Error 2
```
The GNU libtool documentation for `-version-info` says:

> This flag accepts an argument of the form ‘current[:revision[:age]]’. So, passing -version-info 3:12:1 sets current to 3, revision to 12, and age to 1.
>
> If either revision or age are omitted, they default to 0. Also note that age must be less than or equal to the current interface number. 

https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html

Both the syntax of `current[:revision[:age]]` and only defining anything for when `revision` or `age` is missing indicates that at least `current` is required. However GNU libtool is happy to silently ignore this error while slibtool prints an error.
```
rdlibtool: error: option [--version-info] requires a value 
```
If another version value other than `0:0:0` is desired I can change that.

