### PR TITLE
Fix _sasl_add_string

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -195,7 +195,7 @@ int _sasl_add_string(char **out, size_t *alloclen,
     return SASL_NOMEM;
 
   strncpy(*out + *outlen, add, addlen);
-  *outlen += addlen;
+  *outlen += addlen-1;
 
   return SASL_OK;
 }


### PR DESCRIPTION
Issue #587 was not solved correct.

_sasl_add_string adds zero terminator to the output string.
This cuts log messages after the first '%s' of the format string.
With the fix the function _sasl_log now logs the complete message.

Signed-off-by: Guido Kiener <guido@kiener-muenchen.de>