### PR TITLE
Fix iovec name conflict

### DIFF
--- a/common/plugin_common.c
+++ b/common/plugin_common.c
@@ -171,7 +171,7 @@ int _plug_ipfromstring(const sasl_utils_t *utils, const char *addr,
     return SASL_OK;
 }
 
-int _plug_iovec_to_buf(const sasl_utils_t *utils, const struct iovec *vec,
+int _plug_iovec_to_buf(const sasl_utils_t *utils, const cyrus_sasl_iovec *vec,
 		       unsigned numiov, buffer_info_t **output) 
 {
     unsigned i;

--- a/common/plugin_common.h
+++ b/common/plugin_common.h
@@ -148,7 +148,7 @@ extern "C" {
 
 int _plug_ipfromstring(const sasl_utils_t *utils, const char *addr,
 		       struct sockaddr *out, socklen_t outlen);
-int _plug_iovec_to_buf(const sasl_utils_t *utils, const struct iovec *vec,
+int _plug_iovec_to_buf(const sasl_utils_t *utils, const cyrus_sasl_iovec *vec,
 		       unsigned numiov, buffer_info_t **output);
 int _plug_buf_alloc(const sasl_utils_t *utils, char **rwbuf,
 		    unsigned *curlen, unsigned newlen);

--- a/include/sasl.h
+++ b/include/sasl.h
@@ -186,15 +186,17 @@
 
 #ifdef _WIN32
 /* Define to have the same layout as a WSABUF */
-#ifndef STRUCT_IOVEC_DEFINED
-#define STRUCT_IOVEC_DEFINED 1
-struct iovec {
+#ifndef STRUCT_CYRUS_SASL_IOVEC_DEFINED
+#define STRUCT_CYRUS_SASL_IOVEC_DEFINED 1
+struct cyrus_sasl_iovec {
     long iov_len;
     char *iov_base;
 };
+typedef struct cyrus_sasl_iovec cyrus_sasl_iovec;
 #endif
 #else
 struct iovec;				     /* Defined in OS headers */
+typedef struct iovec cyrus_sasl_iovec;
 #endif
 
 
@@ -1307,7 +1309,7 @@ LIBSASL_API int sasl_encode(sasl_conn_t *conn,
  *		     or no security layer
  */
 LIBSASL_API int sasl_encodev(sasl_conn_t *conn,
-			     const struct iovec *invec, unsigned numiov,
+			     const cyrus_sasl_iovec *invec, unsigned numiov,
 			     const char **output, unsigned *outputlen);
 
 /* decode a block of data received using security layer

--- a/include/saslplug.h
+++ b/include/saslplug.h
@@ -183,7 +183,7 @@ typedef struct sasl_out_params {
 	 		    * security layer was *attempted*, even if
 			    * the negotiation failed */
     void *encode_context;
-    int (*encode)(void *context, const struct iovec *invec, unsigned numiov,
+    int (*encode)(void *context, const cyrus_sasl_iovec *invec, unsigned numiov,
 		  const char **output, unsigned *outputlen);
     void *decode_context;
     int (*decode)(void *context, const char *input, unsigned inputlen,

--- a/lib/checkpw.c
+++ b/lib/checkpw.c
@@ -448,7 +448,7 @@ static int write_wait(int fd, unsigned delta)
  * Keep calling the writev() system call with 'fd', 'iov', and 'iovcnt'
  * until all the data is written out or an error/timeout occurs.
  */
-static int retry_writev(int fd, struct iovec *iov, int iovcnt, unsigned delta)
+static int retry_writev(int fd, cyrus_sasl_iovec *iov, int iovcnt, unsigned delta)
 {
     int n;
     int i;
@@ -517,7 +517,7 @@ static int pwcheck_verify_password(sasl_conn_t *conn,
     int s;
     struct sockaddr_un srvaddr;
     int r;
-    struct iovec iov[10];
+    cyrus_sasl_iovec iov[10];
     static char response[1024];
     unsigned start, n;
     char pwpath[1024];
@@ -819,8 +819,8 @@ static int saslauthd_verify_password(sasl_conn_t *conn,
     }
 
     {
- 	struct iovec iov[8];
- 
+	cyrus_sasl_iovec iov[8];
+
 	iov[0].iov_len = query_end - query;
 	iov[0].iov_base = query;
 
@@ -1013,7 +1013,7 @@ static int authdaemon_read(int fd, void *buf0, unsigned sz)
 static int authdaemon_write(int fd, void *buf0, unsigned sz)
 {
     int nw;
-    struct iovec io;
+    cyrus_sasl_iovec io;
     io.iov_len = sz;
     io.iov_base = buf0;
     nw = retry_writev(fd, &io, 1, AUTHDAEMON_IO_TIMEOUT);

--- a/lib/common.c
+++ b/lib/common.c
@@ -287,7 +287,7 @@ int sasl_encode(sasl_conn_t *conn, const char *input,
 		const char **output, unsigned *outputlen)
 {
     int result;
-    struct iovec tmp;
+    cyrus_sasl_iovec tmp;
 
     if(!conn) return SASL_BADPARAM;
     if(!input || !inputlen || !output || !outputlen)
@@ -309,10 +309,10 @@ int sasl_encode(sasl_conn_t *conn, const char *input,
 /* Internal function that doesn't do any verification */
 static int
 _sasl_encodev (sasl_conn_t *conn,
-	       const struct iovec *invec,
+               const cyrus_sasl_iovec *invec,
                unsigned numiov,
                int * p_num_packets,     /* number of packets generated so far */
-	       const char **output,     /* previous output, if *p_num_packets > 0 */
+               const char **output,     /* previous output, if *p_num_packets > 0 */
                unsigned *outputlen)
 {
     int result;
@@ -342,7 +342,7 @@ _sasl_encodev (sasl_conn_t *conn,
                 conn->multipacket_encoded_data.reallen = 
                     conn->multipacket_encoded_data.curlen + SASL_ENCODEV_EXTRA;
 
-	        new_buf = sasl_REALLOC(conn->multipacket_encoded_data.data,
+                new_buf = sasl_REALLOC(conn->multipacket_encoded_data.data,
                             conn->multipacket_encoded_data.reallen + 1);
                 if (new_buf == NULL) {
                     MEMERROR(conn);
@@ -395,17 +395,17 @@ _sasl_encodev (sasl_conn_t *conn,
 /* security-encode an iovec */
 /* output is only valid until the next call to sasl_encode or sasl_encodev */
 int sasl_encodev(sasl_conn_t *conn,
-		 const struct iovec *invec,
+                 const cyrus_sasl_iovec *invec,
                  unsigned numiov,
-		 const char **output,
+                 const char **output,
                  unsigned *outputlen)
 {
     int result = SASL_OK;
     unsigned i;
     unsigned j;
     size_t total_size = 0;
-    struct iovec *cur_invec = NULL;
-    struct iovec last_invec;
+    cyrus_sasl_iovec *cur_invec = NULL;
+    cyrus_sasl_iovec last_invec;
     unsigned cur_numiov;
     char * next_buf = NULL;
     size_t remainder_len;
@@ -465,10 +465,10 @@ int sasl_encodev(sasl_conn_t *conn,
 
             /* +1 --- just in case we need the head record */
             if ((cur_numiov + 1) > allocated) {
-                struct iovec *new_invec;
+                cyrus_sasl_iovec *new_invec;
 
                 allocated = cur_numiov + 1;
-                new_invec = sasl_REALLOC (cur_invec, sizeof(struct iovec) * allocated);
+                new_invec = sasl_REALLOC (cur_invec, sizeof(cyrus_sasl_iovec) * allocated);
                 if (new_invec == NULL) {
                     if (cur_invec != NULL) {
                         sasl_FREE(cur_invec);
@@ -2207,7 +2207,7 @@ void _sasl_get_errorbuf(sasl_conn_t *conn, char ***bufhdl, size_t **lenhdl)
 }
 
 /* convert an iovec to a single buffer */
-int _iovec_to_buf(const struct iovec *vec,
+int _iovec_to_buf(const cyrus_sasl_iovec *vec,
 		  unsigned numiov, buffer_info_t **output) 
 {
     unsigned i;

--- a/lib/saslint.h
+++ b/lib/saslint.h
@@ -426,7 +426,7 @@ extern int _sasl_strdup(const char *in, char **out, size_t *outlen);
 int _buf_alloc(char **rwbuf, size_t *curlen, size_t newlen);
 
 /* convert an iovec to a single buffer */
-int _iovec_to_buf(const struct iovec *vec,
+int _iovec_to_buf(const cyrus_sasl_iovec *vec,
 		  unsigned numiov, buffer_info_t **output);
 
 /* Convert between string formats and sockaddr formats */

--- a/plugins/digestmd5.c
+++ b/plugins/digestmd5.c
@@ -1489,7 +1489,7 @@ static const unsigned short version = 1;
  * len, HMAC(ki, {SeqNum, msg})[0..9], x0001, SeqNum
  */
 static int digestmd5_encode(void *context,
-			    const struct iovec *invec,
+			    const cyrus_sasl_iovec *invec,
 			    unsigned numiov,
 			    const char **output,
 			    unsigned *outputlen)

--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -345,7 +345,7 @@ sasl_gss_seterror_(const sasl_utils_t *utils, OM_uint32 maj, OM_uint32 min,
 }
 
 static int 
-sasl_gss_encode(void *context, const struct iovec *invec, unsigned numiov,
+sasl_gss_encode(void *context, const cyrus_sasl_iovec *invec, unsigned numiov,
 		const char **output, unsigned *outputlen, int privacy)
 {
     context_t *text = (context_t *)context;
@@ -433,14 +433,14 @@ sasl_gss_encode(void *context, const struct iovec *invec, unsigned numiov,
     return SASL_OK;
 }
 
-static int gssapi_privacy_encode(void *context, const struct iovec *invec,
+static int gssapi_privacy_encode(void *context, const cyrus_sasl_iovec *invec,
 				 unsigned numiov, const char **output,
 				 unsigned *outputlen)
 {
     return sasl_gss_encode(context,invec,numiov,output,outputlen,1);
 }
 
-static int gssapi_integrity_encode(void *context, const struct iovec *invec,
+static int gssapi_integrity_encode(void *context, const cyrus_sasl_iovec *invec,
 				   unsigned numiov, const char **output,
 				   unsigned *outputlen) 
 {

--- a/plugins/kerberos4.c
+++ b/plugins/kerberos4.c
@@ -203,7 +203,7 @@ static char *srvtab = NULL;
 static unsigned refcount = 0;
 
 static int kerberosv4_encode(void *context,
-			     const struct iovec *invec,
+			     const cyrus_sasl_iovec *invec,
 			     unsigned numiov,
 			     const char **output,
 			     unsigned *outputlen)

--- a/plugins/ntlm.c
+++ b/plugins/ntlm.c
@@ -108,9 +108,9 @@
 /*****************************  Common Section  *****************************/
 
 #ifdef WIN32
-static ssize_t writev (SOCKET fd, const struct iovec *iov, size_t iovcnt);
+static ssize_t writev (SOCKET fd, const cyrus_sasl_iovec *iov, size_t iovcnt);
 
-ssize_t writev (SOCKET fd, const struct iovec *iov, size_t iovcnt)
+ssize_t writev (SOCKET fd, const cyrus_sasl_iovec *iov, size_t iovcnt)
 {
     ssize_t nwritten;		/* amount written */
     ssize_t nbytes;
@@ -707,7 +707,7 @@ static void unload_session_setup_resp(unsigned char buf[],
  * Keep calling the writev() system call with 'fd', 'iov', and 'iovcnt'
  * until all the data is written out or an error occurs.
  */
-static int retry_writev(SOCKET fd, struct iovec *iov, int iovcnt)
+static int retry_writev(SOCKET fd, cyrus_sasl_iovec *iov, int iovcnt)
 {
     int n;
     int i;
@@ -838,7 +838,7 @@ static SOCKET smb_connect_server(const sasl_utils_t *utils, const char *client,
 
     unsigned char called[34];
     unsigned char calling[34];
-    struct iovec iov[3];
+    cyrus_sasl_iovec iov[3];
     uint32 pkt;
     int rc;
 
@@ -986,7 +986,7 @@ static int smb_negotiate_protocol(const sasl_utils_t *utils,
     uint16 bytecount;
     uint32 len, nl;
     int n_dialects = N(SMB_DIALECTS);
-    struct iovec iov[4+N(SMB_DIALECTS)];
+    cyrus_sasl_iovec iov[4+N(SMB_DIALECTS)];
     int i, n;
     int rc;
     pid_t current_pid;
@@ -1171,7 +1171,7 @@ static int smb_session_setup(const sasl_utils_t *utils, server_context_t *text,
     unsigned char bc[sizeof(uint16)];
     uint16 bytecount;
     uint32 len, nl;
-    struct iovec iov[12];
+    cyrus_sasl_iovec iov[12];
     int i, n;
     int rc;
 #ifdef WIN32

--- a/plugins/passdss.c
+++ b/plugins/passdss.c
@@ -150,7 +150,7 @@ typedef struct context {
 
 
 static int passdss_encode(void *context,
-			  const struct iovec *invec,
+			  const cyrus_sasl_iovec *invec,
 			  unsigned numiov,
 			  const char **output,
 			  unsigned *outputlen)

--- a/plugins/srp.c
+++ b/plugins/srp.c
@@ -281,7 +281,7 @@ typedef struct context {
 } context_t;
 
 static int srp_encode(void *context,
-		      const struct iovec *invec,
+		      const cyrus_sasl_iovec *invec,
 		      unsigned numiov,
 		      const char **output,
 		      unsigned *outputlen)

--- a/saslauthd/auth_rimap.c
+++ b/saslauthd/auth_rimap.c
@@ -459,7 +459,7 @@ auth_rimap (
     /* VARIABLES */
     int	s=-1;				/* socket to remote auth host   */
     struct addrinfo *r;			/* remote socket address info   */
-    struct iovec iov[5];		/* for sending IMAP commands    */
+    cyrus_sasl_iovec iov[5];		/* for sending IMAP commands    */
     char *qlogin;			/* pointer to "quoted" login    */
     char *qpass;			/* pointer to "quoted" password */
     char *c;				/* scratch pointer              */

--- a/saslauthd/testsaslauthd.c
+++ b/saslauthd/testsaslauthd.c
@@ -203,8 +203,8 @@ static int saslauthd_verify_password(const char *saslauthd_path,
     }
 
     {
- 	struct iovec iov[8];
- 
+	cyrus_sasl_iovec iov[8];
+
 	iov[0].iov_len = query_end - query;
 	iov[0].iov_base = query;
 
@@ -214,7 +214,7 @@ static int saslauthd_verify_password(const char *saslauthd_path,
 	    return -1;
 	}
     }
-  
+
     /*
      * read response of the form:
      *
@@ -225,14 +225,14 @@ static int saslauthd_verify_password(const char *saslauthd_path,
         fprintf(stderr,"size read failed\n");
         return -1;
     }
-  
+
     count = ntohs(count);
     if (count < 2) { /* MUST have at least "OK" or "NO" */
 	close(s);
         fprintf(stderr,"bad response from saslauthd\n");
 	return -1;
     }
-  
+
     count = (int)sizeof(response) < count ? sizeof(response) : count;
     if (retry_read(s, response, count) < count) {
 	close(s);

--- a/saslauthd/utils.c
+++ b/saslauthd/utils.c
@@ -163,7 +163,7 @@ ssize_t rx_rec(int filefd, void *prebuff, size_t bytesrequested) {
  * data, without any guarantees. If the function returns 
  * -1, the vector wasn't completely written.
  **************************************************************/
-int retry_writev(int fd, struct iovec *iov, int iovcnt) {
+int retry_writev(int fd, cyrus_sasl_iovec *iov, int iovcnt) {
 	int n;               /* return value from writev() */
 	int i;               /* loop counter */
 	int written;         /* bytes written so far */

--- a/saslauthd/utils.h
+++ b/saslauthd/utils.h
@@ -83,7 +83,7 @@
 extern void	logger(int, const char *, const char *, ...);
 extern ssize_t	tx_rec(int filefd, void *, size_t);
 extern ssize_t	rx_rec(int , void *, size_t);
-extern int	retry_writev(int, struct iovec *, int);
+extern int	retry_writev(int, cyrus_sasl_iovec *, int);
 
 
 #endif  /* _UTILS_H */


### PR DESCRIPTION
Cyrus SASL is not the only library that defined struct iovec when it is not
provided by OS interface (for example, on Windows) -  msgpack-c does the same:
github.com/msgpack/msgpack-c/blob/6e7deb8/include/msgpack/vrefbuffer.h#L16
To avoid name conflicts because of redefinition of struct iovec when using both
libraries in the same project, this commit proposes cyrus_sasl_iovec typedef.