### PR TITLE
Fix _sasl_add_string

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -190,12 +190,12 @@ int _sasl_add_string(char **out, size_t *alloclen,
 
   if (add==NULL) add = "(null)";
 
-  addlen=strlen(add)+1; /* only compute once */
-  if (_buf_alloc(out, alloclen, (*outlen)+addlen)!=SASL_OK)
+  addlen=strlen(add); /* only compute once */
+  if (_buf_alloc(out, alloclen, (*outlen)+addlen+1)!=SASL_OK)
     return SASL_NOMEM;
 
-  strncpy(*out + *outlen, add, addlen);
-  *outlen += addlen-1;
+  strcpy(*out + *outlen, add);
+  *outlen += addlen;
 
   return SASL_OK;
 }


### PR DESCRIPTION
Fix #587 prev fix was incorrect.

_sasl_add_string adds zero terminator to the output string.
This cuts log messages after the first '%s' of the format string.
With the fix the function _sasl_log now logs the complete message.

Signed-off-by: Howard Chu <hyc@symas.com>