### PR TITLE
Update path to installation instructions

### DIFF
--- a/INSTALL.TXT
+++ b/INSTALL.TXT
@@ -1,1 +1,1 @@
-For installation instructions, see doc/install.html.
+For installation instructions, see doc/legacy/install.html.


### PR DESCRIPTION
It looks like the docs recently moved to the `legacy` folder.
If we should rather point to a different resource, we can do so, too.