### PR TITLE
fix build error w/ --enable-auth-sasldb

### DIFF
--- a/saslauthd/auth_sasldb.c
+++ b/saslauthd/auth_sasldb.c
@@ -41,6 +41,7 @@
 #include <unistd.h>
 /* END PUBLIC DEPENDENCIES */
 
+#include "../lib/saslint.h"
 #define RETURN(x) return strdup(x)
 
 
@@ -48,7 +49,6 @@
 #include "../include/sasl.h"
 #include "../include/saslplug.h"
 #include "../sasldb/sasldb.h"
-#include "../saslint.h"
 
 static int
 vf(void *context __attribute__((unused)),


### PR DESCRIPTION
I am doing some development in an ubuntu 20.4 (LTS) (focal) box and had some trouble re-building the package w/o any Debian specific patches. This commit fixes those.

-----
Details:

To build, I use some minimal debian/rules / debian/control files that I have uploaded here: https://github.com/Pfiver/cyrus-sasl/commit/48fb14efcce0e32f3264b057dabb4b2466eb6637

Essentially,
```
configure \
	--prefix=/usr \
	--build=x86_64-linux-gnu \
	\
	--enable-static \
	--enable-shared \
	--enable-alwaystrue \
	--enable-cram \
	--enable-digest \
	--enable-plain \
	--enable-anon \
	--enable-login \
	--enable-ldapdb \
	--enable-auth-sasldb \
	\
	--disable-otp \
	--disable-srp \
	--disable-srp-setpass \
	--disable-krb4 \
	--disable-gssapi \
	--disable-gss_mutexes \
	--disable-sql \
	--disable-ntlm \
	--disable-passdss \
	--disable-checkapop \
	--disable-macos-framework \
	\
	--with-ldap \
	--with-pam=/usr \
	--with-configdir=/etc/sasl2:/etc/sasl:/usr/lib/x86_64-linux-gnu/sasl2:/usr/lib/sasl2 \
	--with-plugindir=/usr/lib/x86_64-linux-gnu/sasl2 \
	--sysconfdir=/etc \
	--with-devrandom=/dev/urandom
...
make
```

And then I get
```
x86_64-linux-gnu-gcc -DHAVE_CONFIG_H -DSASLAUTHD_CONF_FILE_DEFAULT=\"/etc/saslauthd.conf\" -I. -I../../saslauthd -I.. -I. -I../../saslauthd -I..  -I../../include -I../include -I../common -I../../common -Wdate-time -D_FORTIFY_SOURCE=2  -DOBSOLETE_CRAM_ATTR=1 -DOBSOLETE_DIGEST_ATTR=1  -I/usr/include  -Wall -W -g -O2 -fdebug-prefix-map=/home/ubuntu/cyrus-sasl=. -fstack-protector-strong -Wformat -Werror=format-security -c -o auth_sasldb.o ../../saslauthd/auth_sasldb.c
../../saslauthd/auth_sasldb.c:51:10: fatal error: ../saslint.h: No such file or directory
   51 | #include "../saslint.h"
      |          ^~~~~~~~~~~~~~
compilation terminated.
```

If I try fixing that by only adjusting the `saslint.h` path without moving the import above `#define RETURN...`, then there are more errors
```
x86_64-linux-gnu-gcc -DHAVE_CONFIG_H -DSASLAUTHD_CONF_FILE_DEFAULT=\"/etc/saslauthd.conf\" -I. -I../../saslauthd -I.. -I. -I../../saslauthd -I..  -I../../include -I../include -I../common -I../../common -Wdate-time -D_FORTIFY_SOURCE=2  -DOBSOLETE_CRAM_ATTR=1 -DOBSOLETE_DIGEST_ATTR=1  -I/usr/include  -Wall -W -g -O2 -fdebug-prefix-map=/home/ubuntu/cyrus-sasl=. -fstack-protector-strong -Wformat -Werror=format-security -c -o auth_sasldb.o ../../saslauthd/auth_sasldb.c
In file included from ../../saslauthd/auth_sasldb.c:51:
... warnings ...
../../saslauthd/auth_sasldb.c: In function ‘auth_sasldb’:
../../saslauthd/auth_sasldb.c:151:21: error: macro "RETURN" requires 2 arguments, but only 1 given
  151 |  if(ret) RETURN("NO");
      |                     ^
... more warnings and errors ...
```