### PR TITLE
plugins/digestmd5: Remove debug log "mech free"

### DIFF
--- a/plugins/digestmd5.c
+++ b/plugins/digestmd5.c
@@ -1762,9 +1762,6 @@ static void digestmd5_common_mech_free(void *glob_context,
     reauth_cache_t *reauth_cache = my_glob_context->reauth;
     size_t n;
 
-    utils->log(utils->conn, SASL_LOG_DEBUG,
-	       "DIGEST-MD5 common mech free");
- 
     /* Prevent anybody else from freeing this as well */
     my_glob_context->reauth = NULL;
 


### PR DESCRIPTION
The "DIGEST-MD5 common mech free" debug log message is bothering many users.
It is not really helpful, so drop it.

Fixes #386.