### PR TITLE
makemd5: Rebase on top of relicensed upstream

### DIFF
--- a/include/makemd5.c
+++ b/include/makemd5.c
@@ -44,7 +44,7 @@
  */
 
 /*
- * Copyright (c) 1997, 1998 Kungliga Tekniska Högskolan
+ * Copyright (c) 1997 - 1999 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden). 
  * All rights reserved. 
  *
@@ -59,12 +59,7 @@
  *    notice, this list of conditions and the following disclaimer in the 
  *    documentation and/or other materials provided with the distribution. 
  *
- * 3. All advertising materials mentioning features or use of this software 
- *    must display the following acknowledgement: 
- *      This product includes software developed by Kungliga Tekniska 
- *      Högskolan and its contributors. 
- *
- * 4. Neither the name of the Institute nor the names of its contributors 
+ * 3. Neither the name of the Institute nor the names of its contributors
  *    may be used to endorse or promote products derived from this software 
  *    without specific prior written permission. 
  *
@@ -94,8 +89,8 @@ my_strupr(char *s)
 {
     char *p = s;
     while(*p){
-	if(islower((int) *p))
-	    *p = toupper((int) *p);
+	if(islower((unsigned char)*p))
+	    *p = toupper((unsigned char)*p);
 	p++;
     }	
 }
@@ -204,7 +199,7 @@ int main(int argc, char **argv)
     hb = malloc(strlen(fn) + 5);
     sprintf(hb, "__%s__", fn);
     for(p = hb; *p; p++){
-      if(!isalnum((int) *p))
+      if(!isalnum((unsigned char)*p))
 	*p = '_';
     }
     f = fopen(argv[1], "w");
@@ -244,5 +239,5 @@ int main(int argc, char **argv)
   
     fclose(f);
 
-    return 0;  
+    return 0;
 }


### PR DESCRIPTION
Heimdal's bits.c file was relicensed upstream, dropping the BSD advertising
clause. Rebase makemd5.c on top of it.

Keep the changes of commits 77730fef12e9 ("Fix potential out of bound writes")
and 70808c9b9dca ("makemd5: Check for file open errors").

The remainder of the patch are casts that get rid of compiler warnings that
upstream handled with a different type from cyrus-sasl.