### PR TITLE
Clear error from dlsym() so that it is not exposed outside libsasl

### DIFF
--- a/lib/dlopen.c
+++ b/lib/dlopen.c
@@ -211,6 +211,8 @@ int _sasl_locate_entry(void *library, const char *entryname,
     *entry_point = NULL;
     *entry_point = dlsym(library, adj_entryname);
     if (*entry_point == NULL) {
+	/* clear error from dlsym() */
+	dlerror();
 #if 0 /* This message appears to confuse people */
 	_sasl_log(NULL, SASL_LOG_DEBUG,
 		  "unable to get entry point %s: %s", adj_entryname,


### PR DESCRIPTION
I have a service which loads some components using `dlopen()`.  After loading each component it calls `dlerror()` and throws an exception if there is an error.  This used to work fine (ubuntu focal) but doesn't anymore (ubuntu jammy).

The problem is that one of the components depends on libsasl which in turn uses `dlopen()` and `dlsym()` to load its plugins.  Errors happen during plugin loading which are exposed to my service when it calls `dlerror()`.  My suggestion is to call `dlerror()` in libsasl to clear the error.

Also if anyone knows why my service used to work and now doesn't (it hasn't changed), I'd love to know.