### PR TITLE
plugins/gssapi: Don't emit debug log for every step

### DIFF
--- a/plugins/gssapi.c
+++ b/plugins/gssapi.c
@@ -2020,9 +2020,6 @@ static int gssapi_client_mech_step(void *conn_context,
     if (clientoutlen)
         *clientoutlen = 0;
     
-    params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
-		       "GSSAPI client step %d", text->state);
-
     switch (text->state) {
 
     case SASL_GSSAPI_STATE_AUTHNEG:


### PR DESCRIPTION
There's usually no need to spam syslog with 2-4 messages every time SSSD
or ldapsearch or some other GSSAPI client application authenticates to a
server.

Similar to 1a0bb2d3b5cd & e5a027290db1.

---

(as a side note, the "[Contribution guidelines](https://github.com/cyrusimap/cyrus-sasl/blob/master/CONTRIBUTING.md)" say the mailing list should be informed about new PRs, but the [mailing list](https://cyrus.topicbox.com/groups/sasl/Tcd4dcd3adcd023b7-M581a46750331407531edaeee/github-pr-713-install-pluginviewer-8-with-with-dblibnone) says the opposite, so I assume the guidelines file is out of date)