### PR TITLE
Update runtests.py: Fixed an issue where the return value of the function is incorrect.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -213,9 +213,10 @@ def gssapi_channel_binding_mismatch_test(kenv):
                 result = "PASS"
             raise Exception("CLI ({}): {} --> SRV ({}): {}".format(
                 cli.returncode, cli_err, srv.returncode, srv_err))
+        return 0
     except Exception as e:
         print("{}: {}".format(result, e))
-        return 0
+        return 1
 
     print("FAIL: This test should fail [CLI({}) SRV({})]".format(
         cli.stdout.read().decode('utf-8').strip(),


### PR DESCRIPTION
Fixed an issue where the return value of the function is incorrect.[https://github.com/cyrusimap/cyrus-sasl/issues/746](url)
When the gssapi_channel_binding_mismatch_test function is bound successfully, 0 is returned. When an exception occurs, 1 is returned. The function is consistent with other functions of the same type.