### PR TITLE
Do not add unneeded `-lcrypt` in `plain`, `login` plugins

### DIFF
--- a/m4/plain.m4
+++ b/m4/plain.m4
@@ -1,21 +1,11 @@
 dnl Check for PLAIN (and therefore crypt)
 
 AC_DEFUN([SASL_PLAIN_CHK],[
-AC_REQUIRE([SASL2_CRYPT_CHK])
 
 dnl PLAIN
  AC_ARG_ENABLE(plain, [  --enable-plain          enable PLAIN authentication [yes] ],
   plain=$enableval,
   plain=yes)
-
- PLAIN_LIBS=""
- if test "$plain" != no; then
-  dnl In order to compile plain, we need crypt.
-  if test "$cmu_have_crypt" = yes; then
-    PLAIN_LIBS=$LIB_CRYPT
-  fi
- fi
- AC_SUBST(PLAIN_LIBS)
 
  AC_MSG_CHECKING(PLAIN)
  if test "$plain" != no; then

--- a/m4/sasl2.m4
+++ b/m4/sasl2.m4
@@ -1,7 +1,7 @@
 # sasl2.m4--sasl2 libraries and includes
 # Rob Siemborski
 
-# SASL2_CRYPT_CHK
+# SASL_GSSAPI_CHK
 # ---------------
 AC_DEFUN([SASL_GSSAPI_CHK],
 [AC_REQUIRE([SASL2_CRYPT_CHK])

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -72,7 +72,7 @@ EXTRA_LTLIBRARIES = libplain.la libanonymous.la libkerberos4.la libcrammd5.la \
 
 libplain_la_SOURCES = plain.c plain_init.c
 libplain_la_DEPENDENCIES = $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
-libplain_la_LIBADD = $(PLAIN_LIBS) $(LIB_SOCKET) $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
+libplain_la_LIBADD = $(LIB_SOCKET) $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
 
 libanonymous_la_SOURCES = anonymous.c anonymous_init.c
 libanonymous_la_DEPENDENCIES = $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
@@ -104,7 +104,7 @@ libscram_la_LIBADD = $(SCRAM_LIBS) $(LIB_SOCKET) $(COMPAT_OBJS) $(PLUGIN_COMMON_
 
 liblogin_la_SOURCES = login.c login_init.c
 liblogin_la_DEPENDENCIES = $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
-liblogin_la_LIBADD = $(PLAIN_LIBS) $(LIB_SOCKET) $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
+liblogin_la_LIBADD = $(LIB_SOCKET) $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS)
 
 libsrp_la_SOURCES = srp.c srp_init.c
 libsrp_la_DEPENDENCIES = $(COMPAT_OBJS) $(PLUGIN_COMMON_OBJS) $(CRYPTO_COMPAT_OBJS)


### PR DESCRIPTION
The problem is that on newer Linux, for example Arch Linux 2022-09, the deprecated library is missing. This causes plugins to fail to load.

It was last needed more than 20 years ago, and was removed in commit
  74135b68 by Larry Greenfield, 1999-06-23 00:16:37
  latest stuff

Later, `#include <crypt.h>` was also removed in commit
  f58e0357 by Larry Greenfield, 2000-02-27 23:46:15
  removed superfluous includes, brought in line with new checkpass()