### PR TITLE
Use int instead of char for variable c

### DIFF
--- a/utils/testsuite.c
+++ b/utils/testsuite.c
@@ -2938,7 +2938,7 @@ void usage(void)
 
 int main(int argc, char **argv)
 {
-    char c;
+    int c;
     int random_tests = -1;
     int do_all = 0;
     int skip_do_correct = 0;


### PR DESCRIPTION
In some systems, char is compiled as unsigned char by default, as a result, testsuite always fails in abnormal process.