### PR TITLE
fix build on macOS 11+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ if test $sasl_cv_uscore = yes; then
 void foo() { int i=0;}
 int main() { void *self, *ptr1, *ptr2; self=dlopen(NULL,RTLD_LAZY);
     if(self) { ptr1=dlsym(self,"foo"); ptr2=dlsym(self,"_foo");
-    if(ptr1 && !ptr2) exit(0); } exit(1); } 
+    if(ptr1 && !ptr2) return 0; } return 1; } 
 ]])],[sasl_cv_dlsym_adds_uscore=yes],[sasl_cv_dlsym_adds_uscore=no],[AC_MSG_WARN(cross-compiler, we'll do our best)])])
 	LIBS="$cmu_save_LIBS"
       AC_MSG_RESULT($sasl_cv_dlsym_adds_uscore)


### PR DESCRIPTION
On macOS 11+, clang compiler defaults to `-Wimplicit-function-declaration`.

This causes `configure` to incorrectly think that underscores are needed:
```
    configure:15316: checking for underscore before symbols
    configure:15332: result: yes
    configure:15338: checking whether dlsym adds the underscore for us
    configure:15360: gcc -o conftest <...> conftest.c  -ldl >&5
    <...>
	conftest.c:38:23: error: implicitly declaring library function 'exit'
      with type 'void (int) __attribute__((noreturn))'
      [-Werror,-Wimplicit-function-declaration]
        if(ptr1 && !ptr2) exit(0); } exit(1); }
                          ^
    conftest.c:38:23: note: include the header <stdlib.h> or explicitly
      provide a declaration for 'exit'
    1 warning and 1 error generated.
    configure:15360: $? = 1
    configure: program exited with status 1
```

This causes plugins to fail to load (because `dlsym()` looks for wrong symbol).

The fix is to not use `exit()` because a simple `return` is sufficient.

Signed-off-by: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>