### PR TITLE
Support multiple service principals in a single GSSAPI service

### DIFF
--- a/docsrc/sasl/options.rst
+++ b/docsrc/sasl/options.rst
@@ -120,6 +120,22 @@ GSSAPI
    Default: None, if omitted, no credentials cache/delegation and if left
    empty or invalid KRB5CCNAME will be used.
 
+.. option:: ad_compat [yes | no]
+
+   When set to 'yes', 'on', '1' or 'true', a client will request both
+   confidentiality and integrity when required by Active Directory.
+
+   Default: no
+
+.. option:: service_principal [<GSS_C_NT_HOSTBASED_SERVICE> | *]
+
+   Service principal to use when accepting a connection as a server. The
+   principal name must be in GSS_C_NT_HOSTBASED_SERVICE form, e.g.
+   "someservice@someinstance" or "someservice", or the string "*", which
+   causes the server to accept any valid principal present in its keytab.
+
+   Default: <SASL Service Name>@<Server FQDN>
+
 LDAPDB
 ======
 

--- a/tests/t_gssapi_cli.c
+++ b/tests/t_gssapi_cli.c
@@ -17,6 +17,7 @@
 #include <saslutil.h>
 
 const char *testpass = NULL;
+const char *testhost = NULL;
 
 static int setup_socket(void)
 {
@@ -104,11 +105,14 @@ int main(int argc, char *argv[])
     bool spnego = false;
     bool zeromaxssf = false;
 
-    while ((c = getopt(argc, argv, "c:P:zN")) != EOF) {
+    while ((c = getopt(argc, argv, "c:h:P:zN")) != EOF) {
         switch (c) {
         case 'c':
             parse_cb(&cb, cb_buf, 256, optarg);
             break;
+	case 'h':
+	    testhost = optarg;
+	    break;
         case 'P':
             plain = 1;
             testpass = optarg;
@@ -151,7 +155,7 @@ int main(int argc, char *argv[])
     r = sasl_client_init(callbacks);
     if (r != SASL_OK) exit(-1);
 
-    r = sasl_client_new("test", "host.realm.test", NULL, NULL, NULL, 0, &conn);
+    r = sasl_client_new("test", testhost ? testhost : "host.realm.test", NULL, NULL, NULL, 0, &conn);
     if (r != SASL_OK) {
         saslerr(r, "allocating connection state");
         exit(-1);

--- a/tests/t_gssapi_srv.c
+++ b/tests/t_gssapi_srv.c
@@ -17,6 +17,8 @@
 #include <saslplug.h>
 
 const char *sasldb_path = NULL,
+      *keytab = NULL,
+      *service_principal = NULL,
       *auxprop_plugin = "sasldb",
       *pwcheck_method =
 #if 0	/* totally undocumented. See issue#374 */
@@ -69,6 +71,20 @@ static int test_getopt(void *context __attribute__((unused)),
         return SASL_OK;
     }
 
+    if (service_principal && !strcmp(option, "service_principal")) {
+        *result = service_principal;
+        if (len)
+            *len = (unsigned) strlen(service_principal);
+        return SASL_OK;
+    }
+
+    if (keytab && !strcmp(option, "keytab")) {
+        *result = keytab;
+        if (len)
+            *len = (unsigned) strlen(keytab);
+        return SASL_OK;
+    }
+
     if (sasldb_path && !strcmp(option, "auxprop_plugin")) {
         *result = auxprop_plugin;
         if (len)
@@ -101,10 +117,16 @@ int main(int argc, char *argv[])
     bool spnego = false;
     bool zeromaxssf = false;
 
-    while ((c = getopt(argc, argv, "c:P:zN")) != EOF) {
+    while ((c = getopt(argc, argv, "ac:k:p:P:zN")) != EOF) {
         switch (c) {
         case 'c':
             parse_cb(&cb, cb_buf, 256, optarg);
+            break;
+        case 'k':
+            keytab = optarg;
+            break;
+        case 'p':
+            service_principal = optarg;
             break;
         case 'P':
             plain = 1;


### PR DESCRIPTION
With the current code, it's impossible for a single service to accept multiple service principals. This prevents a single server from being known by multiple FQDNs (e.g. the host FQDN and an anycast FQDN). The code also makes assumptions about how the service principal name should be constructed. This PR addresses both issues by adding support for 2 new options:

accept_any_principal: do not specify the service principal name
service_principal: specify the desired service principal name instead of generating it

I'd argue that best practice would be to make accept_any_principal the norm and delete a lot of code, but I didn't want to change existing behaviour.

I also added client support for the existing keytab option.