### PR TITLE
Relicense md5.c

### DIFF
--- a/lib/md5.c
+++ b/lib/md5.c
@@ -1,39 +1,45 @@
-/* MD5C.C - HMAC based on MD5 message-digest algorithm
+/* md5.c - HMAC based on MD5 message-digest algorithm
  */
-
-/* The following RSA-MD license grant stems from RSA's MD5 implementation
-that is contained in RFC 1321. All of that code is gone and the only 3rd
-party code that is contained in this module is the HMAC MD5 implementation
-by Pau-Chen Cheng and Jeff Kraemer that is contained in RFC 2104's Appendix.
-Rob Earhart made changes to the code that are possibly copyrightable.
-
-The module should be relicensed, taking into account a possible RFC 2104
-license (no restrictions mentioned in the document), and Rob Earhart's consent.
-Eliminating this would be a huge benefit for combining cyrus-sasl with GPL
-licensed software.
-*/
-
-/* Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
-rights reserved.
-
-License to copy and use this software is granted provided that it
-is identified as the "RSA Data Security, Inc. MD5 Message-Digest
-Algorithm" in all material mentioning or referencing this software
-or this function.
-
-License is also granted to make and use derivative works provided
-that such works are identified as "derived from the RSA Data
-Security, Inc. MD5 Message-Digest Algorithm" in all material
-mentioning or referencing the derived work.
-
-RSA Data Security, Inc. makes no representations concerning either
-the merchantability of this software or the suitability of this
-software for any particular purpose. It is provided "as is"
-without express or implied warranty of any kind.
-
-These notices must be retained in any copies of any part of this
-documentation and/or software.
-*/
+/*
+ * Copyright (c) 1998-1999 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any other legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 
 #include <config.h>
 #include "hmac-md5.h"


### PR DESCRIPTION
"As explained in dffe0b3e86925c95e6f30ec0f2de9fb0c439c7bc, the RSA-MD-licensed file md5.c can be relicensed easily because the third-party code that was licensed under RSA-MD is eliminated by now."
-- Bastian Germann <bage@debian.org> in GitHub issue #769

The commit referenced was part of GitHub PR #767 and was authored by Bastian Germann.

I reviewed the commit history on this file.  I concurred with Bastian's original assessment that the relevant detail was Rob Earhart's code, and Bastian agreed with my analysis in the bug.

The next step was confirming that the MD5 code that Rob Earhart contributed was/is licensed under the same license as the rest of the project.  This is a reasonable assumption, as he was one of the main authors of the original code, and everything else he contributed was under that license.

However, to avoid ambiguity or assumptions, I emailed Rob Earhart. He responded today, confirming:

On 2023-06-28 12:14, Rob Earhart wrote:
> Any code I wrote for the Cyrus SASL project has my permission to be
> used under that main license.

Fixes #769