### PR TITLE
Match srp_[client|server]_plug_init header in implementation

### DIFF
--- a/plugins/srp.c
+++ b/plugins/srp.c
@@ -2410,8 +2410,7 @@ int srp_server_plug_init(const sasl_utils_t *utils,
 			 int maxversion,
 			 int *out_version,
 			 const sasl_server_plug_t **pluglist,
-			 int *plugcount,
-			 const char *plugname __attribute__((unused)))
+			 int *plugcount)
 {
     const char *mda;
     unsigned int len;
@@ -3149,8 +3148,7 @@ int srp_client_plug_init(const sasl_utils_t *utils __attribute__((unused)),
 			 int maxversion,
 			 int *out_version,
 			 const sasl_client_plug_t **pluglist,
-			 int *plugcount,
-			 const char *plugname __attribute__((unused)))
+			 int *plugcount)
 {
     layer_option_t *opts;
     


### PR DESCRIPTION
The src_client_plug_init / src_server_plug_init function implementations in plugins/srp.c have a last unused argument "plugname" which is not in the prototype generated by the SASL_CLIENT_PLUG_INIT / SASL_SERVER_PLUG_INIT macros from common/plugin_common.h.

This leads to 2 compilations warnings:
plugins/srp_init.c:41:1:
warning: type of 'srp_client_plug_init' does not match original declaration [-Wlto-type-mismatch] plugins/srp_init.c:42:1:
warning: type of 'srp_server_plug_init' does not match original declaration [-Wlto-type-mismatch]

Drop the unused argument.

Fixes: #757