### PR TITLE
auth_krb5: compare realms before fetching credentials

### DIFF
--- a/saslauthd/auth_krb5.c
+++ b/saslauthd/auth_krb5.c
@@ -203,9 +203,26 @@ auth_krb5 (
         return strdup("NO saslauthd internal error");
     }
 
+    if ((rc = krb5_sname_to_principal(context, servername, verify_principal,
+                                KRB5_NT_SRV_HST, &server))) {
+        k5support_log_err(LOG_DEBUG, context, rc, "krb5_sname_to_principal");
+        krb5_free_principal(context, auth_user);
+        krb5_free_context(context);
+        return strdup("NO saslauthd internal error");
+    }
+
+    if (!krb5_realm_compare(context, auth_user, server)) {
+        syslog(LOG_ERR, "auth_krb5: realm mismatch for %s", principalbuf);
+        krb5_free_principal(context, auth_user);
+        krb5_free_principal(context, server);
+        krb5_free_context(context);
+        return strdup("NO saslauthd realm mismatch");
+    }
+
     if ((rc = krb5_get_init_creds_opt_alloc(context, &opt))) {
         k5support_log_err(LOG_ERR, context, rc, "krb5_get_init_creds_opt_alloc");
         krb5_free_principal(context, auth_user);
+        krb5_free_principal(context, server);
         krb5_free_context(context);
         return strdup("NO saslauthd internal error");
     }
@@ -222,6 +239,7 @@ auth_krb5 (
     if (rc) {
         k5support_log_err(LOG_ERR, context, rc, "krb5_get_init_creds_password");
         krb5_free_principal(context, auth_user);
+        krb5_free_principal(context, server);
         krb5_free_context(context);
         return strdup("NO krb5_get_init_creds_password failed");
     }
@@ -230,22 +248,11 @@ auth_krb5 (
         if ((rc = krb5_kt_resolve(context, keytabname, &kt))) {
             k5support_log_err(LOG_DEBUG, context, rc, "krb5_kt_resolve");
             krb5_free_principal(context, auth_user);
+            krb5_free_principal(context, server);
             krb5_free_cred_contents(context, &cred);
             krb5_free_context(context);
             return strdup("NO saslauthd internal error");
         }
-    }
-
-    if ((rc = krb5_sname_to_principal(context, servername, verify_principal,
-                                KRB5_NT_SRV_HST, &server))) {
-        k5support_log_err(LOG_DEBUG, context, rc, "krb5_sname_to_principal");
-        krb5_free_principal(context, auth_user);
-        krb5_free_cred_contents(context, &cred);
-        if (kt) {
-            krb5_kt_close(context, kt);
-        }
-        krb5_free_context(context);
-        return strdup("NO saslauthd internal error");
     }
 
     krb5_verify_init_creds_opt_init(&vopt);


### PR DESCRIPTION
This avoids unnecessary network calls that attempt to get a useless ticket.

We've been running this in production for a while, in response to an incident where clients attempting to log in to an incorrect but resolvable realm with unreachable KDCs took quite a while to time out and tied up server resources.