### PR TITLE
auth_krb5: add flag to automatically uppercase realms

### DIFF
--- a/saslauthd/auth_krb5.c
+++ b/saslauthd/auth_krb5.c
@@ -40,6 +40,7 @@ static char *verify_principal = "host"; /* a principal in the default keytab */
 static char *servername = NULL; /* server name to use in principal */
 #endif /* AUTH_KRB5 */
 
+#include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -142,7 +143,15 @@ form_principal_name (
     if ((plen <= 0) || (plen >= pnamelen))
 	return -1;
 
-    /* Perhaps we should uppercase the realm? */
+    /* Uppercase the realm. */
+    if (config && cfile_getswitch(config, "krb5_uppercase_realm", 0)) {
+        if (realm && realm[0]) {
+            char *at;
+            for (at = strrchr(pname, '@'); *at; at++) {
+                *at = toupper(*at);
+            }
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
This avoids the unpleasant UX on some services of `uniqname@umich.edu` not working for login when `uniqname@UMICH.EDU` does.

Our initial implementation was to apply this transformation unconditionally, but [Kerberos realms are case-sensitive](https://datatracker.ietf.org/doc/html/rfc4120#section-6.1) (uppercase realms are just a convention) so I made a config flag that defaults off for backwards compatibility.