### PR TITLE
Correct m4 syntax error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,7 @@ AC_ARG_ENABLE(keep_db_open, [  --enable-keep-db-open   keep handle to DB open fo
                 keep_db_open=no)
 
 # Disable if LMDB is not used
-if "$dblib" != lmdb; then
+if test "$dblib" != lmdb; then
   keep_db_open=no
 fi
 

--- a/m4/sasldb.m4
+++ b/m4/sasldb.m4
@@ -76,6 +76,7 @@ dnl named.  arg.
 					     SASL_DB_LIB="-lgdbm", dblib="no")],
   			     dblib="no")
 	  fi
+	fi
 	;;
   none)
 	;;


### PR DESCRIPTION
0b104e52fe (Fix 718 - Remove BDB support) has removed a m4 fi and a configure.ac test verb. Recover them.

This should go to 2.1.29!