### PR TITLE
sample: Rename dprint function

### DIFF
--- a/sample/client.c
+++ b/sample/client.c
@@ -252,9 +252,9 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
     int r, c;
 
     /* get the capability list */
-    dprintf(0, "receiving capability list... ");
+    debug_printf(0, "receiving capability list... ");
     len = recv_string(in, buf, sizeof buf);
-    dprintf(0, "%s\n", buf);
+    debug_printf(0, "%s\n", buf);
 
     if (mech) {
 	/* make sure that 'mech' appears in 'buf' */
@@ -273,7 +273,7 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
 	return -1;
     }
     
-    dprintf(1, "using mechanism %s\n", chosenmech);
+    debug_printf(1, "using mechanism %s\n", chosenmech);
 
     /* we send up to 3 strings;
        the mechanism chosen, the presence of initial response,
@@ -287,7 +287,7 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
     }
 
     for (;;) {
-	dprintf(2, "waiting for server reply...\n");
+	debug_printf(2, "waiting for server reply...\n");
 
 	c = fgetc(in);
 	switch (c) {
@@ -314,10 +314,10 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
 	}
 
 	if (data) {
-	    dprintf(2, "sending response length %d...\n", len);
+	    debug_printf(2, "sending response length %d...\n", len);
 	    send_string(out, data, len);
 	} else {
-	    dprintf(2, "sending null response...\n");
+	    debug_printf(2, "sending null response...\n");
 	    send_string(out, "", 0);
 	}
     }

--- a/sample/common.c
+++ b/sample/common.c
@@ -127,7 +127,7 @@ int recv_string(FILE *f, char *buf, int buflen)
 
 int debuglevel = 0;
 
-int dprintf(int lvl, const char *fmt, ...)
+int debug_printf(int lvl, const char *fmt, ...)
 {
     va_list ap;
     int ret = 0;

--- a/sample/common.h
+++ b/sample/common.h
@@ -43,7 +43,7 @@ extern int send_string(FILE *f, const char *s, int l);
 extern int recv_string(FILE *f, char *buf, int buflen);
 
 extern int debuglevel;
-extern int dprintf(int lvl, const char *fmt, ...);
+extern int debug_printf(int lvl, const char *fmt, ...);
 
 extern void saslerr(int why, const char *what);
 extern void saslfail(int why, const char *what);

--- a/sample/server.c
+++ b/sample/server.c
@@ -227,17 +227,17 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
     
     /* generate the capability list */
     if (mech) {
-	dprintf(2, "forcing use of mechanism %s\n", mech);
+	debug_printf(2, "forcing use of mechanism %s\n", mech);
 	data = strdup(mech);
 	len = strlen(data);
     } else {
 	int count;
 
-	dprintf(1, "generating client mechanism list... ");
+	debug_printf(1, "generating client mechanism list... ");
 	r = sasl_listmech(conn, NULL, NULL, " ", NULL,
 			  &data, (unsigned int *) &len, &count);
 	if (r != SASL_OK) saslfail(r, "generating mechanism list");
-	dprintf(1, "%d mechanisms\n", count);
+	debug_printf(1, "%d mechanisms\n", count);
     }
 
     /* send capability list to client */
@@ -245,7 +245,7 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
     if (mech)
 	free((void *) data);
 
-    dprintf(1, "waiting for client mechanism...\n");
+    debug_printf(1, "waiting for client mechanism...\n");
     len = recv_string(in, chosenmech, sizeof chosenmech);
     if (len <= 0) {
 	printf("client didn't choose mechanism\n");
@@ -290,16 +290,16 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
 
     while (r == SASL_CONTINUE) {
 	if (data) {
-	    dprintf(2, "sending response length %d...\n", len);
+	    debug_printf(2, "sending response length %d...\n", len);
 	    fputc('C', out); /* send CONTINUE to client */
 	    send_string(out, data, len);
 	} else {
-	    dprintf(2, "sending null response...\n");
+	    debug_printf(2, "sending null response...\n");
 	    fputc('C', out); /* send CONTINUE to client */
 	    send_string(out, "", 0);
 	}
 
-	dprintf(1, "waiting for client reply...\n");
+	debug_printf(1, "waiting for client reply...\n");
 	len = recv_string(in, buf, sizeof buf);
 	if (len < 0) {
 	    printf("client disconnected\n");
@@ -324,7 +324,7 @@ int mysasl_negotiate(FILE *in, FILE *out, sasl_conn_t *conn)
 
     fputc('O', out); /* send OK to client */
     fflush(out);
-    dprintf(1, "negotiation complete\n");
+    debug_printf(1, "negotiation complete\n");
 
     r = sasl_getprop(conn, SASL_USERNAME, (const void **) &userid);
     printf("successful authentication '%s'\n", userid);


### PR DESCRIPTION
The function name collides with a macro defined by glibc for gcc < 4.3 and clang. Rename to prevent that.

Fixes #657
Replaces #616