### PR TITLE
opaque: Add missing include

### DIFF
--- a/plugins/opaque_impl.c
+++ b/plugins/opaque_impl.c
@@ -19,6 +19,8 @@
 */
 
 #include "opaque.h"
+#include <string.h>
+
 #if _WIN32 == 1 || _WIN64 == 1
 #include <winsock2.h>
 #else


### PR DESCRIPTION
memcpy() is used in the opaque implementation and needs string.h.