### PR TITLE
Remove SASL_DES_CHK call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,8 +329,6 @@ else
   AC_MSG_RESULT(disabled)
 fi
 
-SASL_DES_CHK
-
 dnl SCRAM
 AC_ARG_ENABLE(scram, [  --enable-scram            enable SCRAM authentication [[yes]] ],
   scram=$enableval,


### PR DESCRIPTION
aa0cf8b47a (Delete Kerberos V4 support) removed the SASL_DES_CHK definition and implementation. Remove the configure call.