### PR TITLE
Remove redudant and non-portable PIC flag (#798)

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -48,7 +48,7 @@
 plugin_common_version = 3:0:0
 crypto_compat_version = 0:0:0
 
-AM_CPPFLAGS=-fPIC -I$(top_srcdir)/include -I$(top_builddir)/include
+AM_CPPFLAGS=-I$(top_srcdir)/include -I$(top_builddir)/include
 
 noinst_LTLIBRARIES = libplugin_common.la libcrypto_compat.la
 

--- a/sasldb/Makefile.am
+++ b/sasldb/Makefile.am
@@ -44,7 +44,7 @@
 # Note that this doesn't necessaraly follow the libsasl2 verison info
 sasl_version = 1:25:0
 
-AM_CPPFLAGS=-DLIBSASL_EXPORTS=1 -fPIC -I$(top_srcdir)/include -I$(top_builddir)/include @SASL_DB_INC@
+AM_CPPFLAGS=-DLIBSASL_EXPORTS=1 -I$(top_srcdir)/include -I$(top_builddir)/include @SASL_DB_INC@
 
 extra_common_sources = db_none.c db_lmdb.c db_ndbm.c db_gdbm.c
 


### PR DESCRIPTION
The errornously provided PIC flag "-fPIC" (to AM_CPPFLAGS) is non-portable and not required since the generated libtool script will contain the correct PIC flag for the target platform and compiler.

This fixed #798