### PR TITLE
SCRAM: Client does not check low iteration counter #811

### DIFF
--- a/plugins/scram.c
+++ b/plugins/scram.c
@@ -2455,8 +2455,11 @@ scram_client_mech_step2(client_context_t *text,
     }
 
     if (text->iteration_count < MIN_ITERATION_COUNTER) {
+	SETERROR(params->utils, "iteration-count is too small, refusing to compute");
+	result = SASL_BADPROT;
+	goto cleanup;
     }
-    
+
     if (text->iteration_count > MAX_ITERATION_COUNTER) {
 	SETERROR(params->utils, "iteration-count is too big, refusing to compute");
 	result = SASL_BADPROT;


### PR DESCRIPTION
Using mechanism SCRAM, a client does not abort authentication when the given iteration counter is lower than 4096.

A hostile server can send a small iteration counter (e.g. 1) and forces the client to send a ClientProof that is calculated with lowest computation time. Thus the hostile server can recover the client's password faster with an offline dictionary or brute-force attack.

This fix compares the iteration counter with the recommended minimum of 4096 and aborts the authentication if the server violates the recommended minimum.