### PR TITLE
More Win32 build fixes

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -72,6 +72,7 @@
 #define _WIN32_WINNT 0x0400
 #include <windows.h>
 #include <process.h>
+#include <tchar.h>
 #endif
 
 static const char *implementation_string = "Cyrus SASL";
@@ -2747,11 +2748,11 @@ _sasl_get_default_path(void *context __attribute__((unused)),
         break;
 
     default:
-        return_value = NULL;
+        *value = NULL;
         goto CLEANUP;
     }
 
-    return_value = ValueData; /* just to flag we have a result */
+    *value = ValueData; /* just to flag we have a result */
 
 CLEANUP:
     RegCloseKey(hKey);

--- a/lib/saslutil.c
+++ b/lib/saslutil.c
@@ -585,7 +585,8 @@ LOWERCASE:
     return (0);
 }
 
-#if defined(WIN32) && !defined(__MINGW64_VERSION_MAJOR)
+#if defined(WIN32)
+#if !defined(__MINGW64_VERSION_MAJOR)
 /***************************************************************************** 
  * 
  *  MODULE NAME : GETOPT.C 
@@ -761,6 +762,7 @@ int getopt(int argc, char *argv[], char *opstring)
         return (int)*pArgString;    /* return the letter that matched */ 
     } 
 } 
+#endif /* !MINGW */
 
 #ifndef PASSWORD_MAX
 #  define PASSWORD_MAX 255

--- a/lib/windlopen.c
+++ b/lib/windlopen.c
@@ -48,6 +48,7 @@
 
 #include <config.h>
 #include <sasl.h>
+#include <tchar.h>
 #include "saslint.h"
 #include "staticopen.h"
 

--- a/sample/client.c
+++ b/sample/client.c
@@ -72,6 +72,7 @@
 
 #include <sasl.h>
 #include <saslplug.h>
+#include <saslutil.h>
 
 #include "common.h"
 


### PR DESCRIPTION
Some missing #includes, minor stuff.

Reminder: you must run configure with `--without-saslauthd --without-authdaemond` since there's no Windows IPC support in either of those.
