### PR TITLE
Fix heap corruption

### DIFF
--- a/lib/server.c
+++ b/lib/server.c
@@ -1764,7 +1764,7 @@ int _sasl_server_listmech(sasl_conn_t *conn,
       INTERROR(conn, SASL_NOMECH);
 
   resultlen = (prefix ? strlen(prefix) : 0)
-            + (strlen(mysep) * (s_conn->mech_length - 1) * 2)
+            + (strlen(mysep) * (s_conn->mech_length * 2 - 1))
 	    + (mech_names_len(s_conn->mech_list) * 2) /* including -PLUS variant */
 	    + (s_conn->mech_length * (sizeof("-PLUS") - 1))
             + (suffix ? strlen(suffix) : 0)


### PR DESCRIPTION
Calculation of resultlen is wrong. E.g. if server allows only one mechanism SCRAM-SHA-256, the expected string for the mechlist_buf is "SCRAM-SHA-256-PLUS SCRAM-SHA-256" with a required size of 33 bytes and not 32 bytes.
Note that (strlen(mysep) * (s_conn->mech_length - 1) * 2) = 0 when s_conn->mech_length = 1.