### PR TITLE
sasl2.m4: Check for gssapi_krb5.h before testing a resulting value

### DIFF
--- a/m4/sasl2.m4
+++ b/m4/sasl2.m4
@@ -269,9 +269,9 @@ if test "$gssapi" != no; then
 
   cmu_save_LIBS="$LIBS"
   LIBS="$LIBS $GSSAPIBASE_LIBS"
+  AC_CHECK_HEADERS(gssapi/gssapi_krb5.h)
   AC_CHECK_FUNCS(gsskrb5_register_acceptor_identity)
   if test "$ac_cv_func_gsskrb5_register_acceptor_identity" = no ; then
-    AC_CHECK_HEADERS(gssapi/gssapi_krb5.h)
     if test "$ac_cv_header_gssapi_gssapi_krb5_h" = "yes"; then
       AC_CHECK_DECL(gsskrb5_register_acceptor_identity,
                     [AC_DEFINE(HAVE_GSSKRB5_REGISTER_ACCEPTOR_IDENTITY,1,


### PR DESCRIPTION
When <gssapi/gssapi_krb5.h> stems from Heimdal but build-heimdal/config.h doesn't define HAVE_GSSAPI_GSSAPI_KRB5_H, <gssapi/gssapi_krb5.h> is not included.

The header file is only checked if gsskrb5_register_acceptor_identity is not found.

Move the header check so that it works for both KRB5 and Heimdal.

Link: https://bugs.debian.org/1066214