### PR TITLE
saslauthd: Relicense auth_pam under BSD-2-Clause

### DIFF
--- a/saslauthd/auth_pam.c
+++ b/saslauthd/auth_pam.c
@@ -7,19 +7,13 @@
  * modification, are permitted provided that the following conditions
  * are met:
  *
- * 1. Redistributions of source code must retain any existing copyright
- *    notice, and this entire permission notice in its entirety,
- *    including the disclaimer of warranties.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the
  *    distribution.
- *
- * 2. Redistributions in binary form must reproduce all prior and current
- *    copyright notices, this list of conditions, and the following
- *    disclaimer in the documentation and/or other materials provided
- *    with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
  * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/saslauthd/auth_pam.h
+++ b/saslauthd/auth_pam.h
@@ -5,19 +5,13 @@
  * modification, are permitted provided that the following conditions
  * are met:
  *
- * 1. Redistributions of source code must retain any existing copyright
- *    notice, and this entire permission notice in its entirety,
- *    including the disclaimer of warranties.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the
  *    distribution.
- *
- * 2. Redistributions in binary form must reproduce all prior and current
- *    copyright notices, this list of conditions, and the following
- *    disclaimer in the documentation and/or other materials provided
- *    with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
  * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF


### PR DESCRIPTION
Fabian Knittel agreed to changing the license to the standard BSD-2-clause license in the linked GitHub issue.

Fixes: #698