### PR TITLE
Fix races in sasl_{client,server}_init()

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -848,7 +848,7 @@ int _sasl_conn_init(sasl_conn_t *conn,
   RETURN(conn, SASL_OK);
 }
 
-int _sasl_common_init(sasl_global_callbacks_t *global_callbacks)
+int _sasl_common_init(sasl_global_callbacks_t *global_callbacks, void **mutex)
 {
     int result;
 
@@ -868,7 +868,7 @@ int _sasl_common_init(sasl_global_callbacks_t *global_callbacks)
 	global_utils->getopt = &_sasl_global_getopt;
 	global_utils->getopt_context = global_callbacks;
 
-	sasl_MUTEX_UNLOCK(free_mutex);
+	*mutex = free_mutex;
 	return SASL_OK;
     } else {
 	sasl_global_utils = _sasl_alloc_utils(NULL, global_callbacks);
@@ -884,7 +884,11 @@ int _sasl_common_init(sasl_global_callbacks_t *global_callbacks)
 	result = SASL_FAIL;
     }
 
-    sasl_MUTEX_UNLOCK(free_mutex);
+    if (result == SASL_OK) {
+	*mutex = free_mutex;
+    } else {
+	sasl_MUTEX_UNLOCK(free_mutex);
+    }
     return result;
 }
 

--- a/lib/saslint.h
+++ b/lib/saslint.h
@@ -384,7 +384,8 @@ _sasl_find_getconfpath_callback(const sasl_callback_t *callbacks);
 extern const sasl_callback_t *
 _sasl_find_verifyfile_callback(const sasl_callback_t *callbacks);
 
-extern int _sasl_common_init(sasl_global_callbacks_t *global_callbacks);
+extern int _sasl_common_init(sasl_global_callbacks_t *global_callbacks,
+			     void **mutex);
 
 extern int _sasl_conn_init(sasl_conn_t *conn,
 			   const char *service,


### PR DESCRIPTION
Should address https://github.com/cyrusimap/cyrus-sasl/issues/584#issuecomment-2019374753, @adamyi, can you confirm it works for you?

Admittedly a more complete overhaul of the `_init()`/`_close()` functions is warranted but I don't have a good approach for that yet.