### PR TITLE
docsrc: Correct rst syntax

### DIFF
--- a/docsrc/sasl/reference/manpages/library/sasl_decode64.rst
+++ b/docsrc/sasl/reference/manpages/library/sasl_decode64.rst
@@ -24,7 +24,7 @@ Synopsis
 Description
 ===========
 
-.. c:function::   int sasl_decode64(const char * input, unsigned inputlen, const char ** output, unasigned outmax, unsigned * outputlen);
+.. c:function::   int sasl_decode64(const char * input, unsigned inputlen, const char ** output, unsigned outmax, unsigned * outputlen);
 
 
     **sasl_decode64** decodes a base64 encoded buffer.

--- a/docsrc/sasl/reference/manpages/library/sasl_dispose.rst
+++ b/docsrc/sasl/reference/manpages/library/sasl_dispose.rst
@@ -19,7 +19,7 @@ Synopsis
 Description
 ===========
 
-.. c:function:: int sasl_encode(sasl_conn_t *conn, const char * input, unsigned inputlen, const char ** output, unsigned * outputlen);
+.. c:function:: int sasl_dispose(sasl_conn_t *conn)
 
     **sasl_dispose** is called when a SASL connection object is no longer needed.
 

--- a/docsrc/sasl/reference/manpages/library/sasl_encode.rst
+++ b/docsrc/sasl/reference/manpages/library/sasl_encode.rst
@@ -20,12 +20,6 @@ Synopsis
                     const char ** output,
                     unsigned * outputlen);
 
-    int sasl_encodev(sasl_conn_t *conn,
-                    const struct iovec * invec,
-                    unsigned numiov,
-                    const char ** output,
-                    unsigned * outputlen);
-
 
 Description
 ===========
@@ -40,15 +34,6 @@ output is identical to the input.
 of a character buffer.
 
 .. c:function:: int sasl_encode(sasl_conn_t *conn, const char * input, unsigned inputlen, const char ** output, unsigned * outputlen);
-
-    :param conn: is the SASL connection context
-
-    :param output: contains the decoded data and is allocated/freed by
-        the library.
-
-    :param outputlen: length of `output`.
-
-    .. c:function:: int sasl_encodev(sasl_conn_t *conn, const struct iovec * invec, unsigned numiov, const char ** output, unsigned * outputlen);
 
     :param conn: is the SASL connection context
 

--- a/docsrc/sasl/reference/manpages/library/sasl_encodev.rst
+++ b/docsrc/sasl/reference/manpages/library/sasl_encodev.rst
@@ -14,12 +14,6 @@ Synopsis
 
     #include <sasl/sasl.h>
 
-    int sasl_encode(sasl_conn_t *conn,
-                    const char * input,
-                    unsigned inputlen,
-                    const char ** output,
-                    unsigned * outputlen);
-
     int sasl_encodev(sasl_conn_t *conn,
                     const struct iovec * invec,
                     unsigned numiov,
@@ -30,25 +24,16 @@ Synopsis
 Description
 ===========
 
-**sasl_encode** encodes data to be sent to be sent to a remote host  who  we’ve
+**sasl_encodev** encodes data to be sent to be sent to a remote host  who  we’ve
 had  a successful authentication session with. If there  is  a  negotiated
 security  the  data  in signed/encrypted  and  the  output  should be sent
 without modification to the remote host. If there is  no  security layer the
 output is identical to the input.
 
-**sasl_encodev** does the same, but for a `struct iovec` instead
-of a character buffer.
+**sasl_encode** does the same, but for a character buffer instead
+of a `struct iovec`.
 
-.. c:function:: int sasl_encode(sasl_conn_t *conn, const char * input, unsigned inputlen, const char ** output, unsigned * outputlen);
-
-    :param conn: is the SASL connection context
-
-    :param output: contains the decoded data and is allocated/freed by
-        the library.
-
-    :param outputlen: length of `output`.
-
-    .. c:function:: int sasl_encodev(sasl_conn_t *conn, const struct iovec * invec, unsigned numiov, const char ** output, unsigned * outputlen);
+.. c:function:: int sasl_encodev(sasl_conn_t *conn, const struct iovec * invec, unsigned numiov, const char ** output, unsigned * outputlen);
 
     :param conn: is the SASL connection context
 


### PR DESCRIPTION
sasl_encode and sasl_encodev were defined twice. Reduce the definitions to one for each document.

sasl_dispose had the wrong definition (copy/paste error). Replace it.

sasl_decode64 has a typo in unasigned. Correct it.

This is a follow-up on #817