### PR TITLE
Add compatibility for gcc 15

### DIFF
--- a/lib/auxprop.c
+++ b/lib/auxprop.c
@@ -780,7 +780,7 @@ int sasl_auxprop_request(sasl_conn_t *conn, const char **propnames)
     }
     
     result = prop_request(sconn->sparams->propctx, propnames);
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 

--- a/lib/canonusr.c
+++ b/lib/canonusr.c
@@ -192,7 +192,7 @@ int _sasl_canon_user(sasl_conn_t *conn,
 	oparams->user = conn->user_buf;
     }
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* Lookup all properties for authentication and/or authorization identity. */
@@ -256,7 +256,7 @@ static int _sasl_auxprop_lookup_user_props (sasl_conn_t *conn,
     }
 #endif
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* default behavior:
@@ -285,7 +285,7 @@ int _sasl_canon_user_lookup (sasl_conn_t *conn,
 						  oparams);
     }
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 void _sasl_canonuser_free() 

--- a/lib/client.c
+++ b/lib/client.c
@@ -452,7 +452,7 @@ int sasl_client_new(const char *service,
 			   &client_idle, serverFQDN,
 			   iplocalport, ipremoteport,
 			   prompt_supp, &global_callbacks_client);
-  if (result != SASL_OK) RETURN(*pconn, result);
+  if (result != SASL_OK) RETURN_VAL(*pconn, result);
   
   utils = _sasl_alloc_utils(*pconn, &global_callbacks_client);
   if (utils == NULL) {
@@ -898,7 +898,7 @@ int sasl_client_start(sasl_conn_t *conn,
  done:
     if (ordered_mechs != NULL)
 	c_conn->cparams->utils->free(ordered_mechs);
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* do a single authentication step.
@@ -971,7 +971,7 @@ int sasl_client_step(sasl_conn_t *conn,
       }
   }  
 
-  RETURN(conn,result);
+  RETURN_VAL(conn,result);
 }
 
 /* returns the length of all the mechanisms

--- a/lib/common.c
+++ b/lib/common.c
@@ -359,7 +359,7 @@ int sasl_encode(sasl_conn_t *conn, const char *input,
     
     result = sasl_encodev(conn, &tmp, 1, output, outputlen);
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* Internal function that doesn't do any verification */
@@ -445,7 +445,7 @@ _sasl_encodev (sasl_conn_t *conn,
 
     (*p_num_packets)++;
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* security-encode an iovec */
@@ -491,7 +491,7 @@ int sasl_encodev(sasl_conn_t *conn,
 	*output = conn->encode_buf->data;
 	*outputlen = (unsigned) conn->encode_buf->curlen;
 
-        RETURN(conn, result);
+        RETURN_VAL(conn, result);
     }
 
     /* This might be better to check on a per-plugin basis, but I think
@@ -649,7 +649,7 @@ cleanup:
         sasl_FREE(cur_invec);
     }
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
  
 /* output is only valid until next call to sasl_decode */
@@ -666,7 +666,7 @@ int sasl_decode(sasl_conn_t *conn,
     if(!conn->props.maxbufsize) {
 	sasl_seterror(conn, 0,
 		      "called sasl_decode with application that does not support security layers");
-	RETURN(conn, SASL_TOOWEAK);
+	RETURN_VAL(conn, SASL_TOOWEAK);
     }
 
     if(conn->oparams.decode == NULL)
@@ -680,7 +680,7 @@ int sasl_decode(sasl_conn_t *conn,
 	if(inputlen > conn->props.maxbufsize) {
 	    sasl_seterror(conn, 0,
 			  "input too large for default sasl_decode");
-	    RETURN(conn,SASL_BUFOVER);
+	    RETURN_VAL(conn,SASL_BUFOVER);
 	}
 
 	if(!conn->decode_buf)
@@ -701,7 +701,7 @@ int sasl_decode(sasl_conn_t *conn,
 	/* NULL an empty buffer (for misbehaved applications) */
 	if (*outputlen == 0) *output = NULL;
 
-        RETURN(conn, result);
+        RETURN_VAL(conn, result);
     }
 
     INTERROR(conn, SASL_FAIL);
@@ -797,11 +797,11 @@ int _sasl_conn_init(sasl_conn_t *conn,
 
   result = sasl_setprop(conn, SASL_IPLOCALPORT, iplocalport);
   if(result != SASL_OK)
-      RETURN(conn, result);
+      RETURN_VAL(conn, result);
   
   result = sasl_setprop(conn, SASL_IPREMOTEPORT, ipremoteport);
   if(result != SASL_OK)
-      RETURN(conn, result);
+      RETURN_VAL(conn, result);
   
   conn->encode_buf = NULL;
   conn->context = NULL;
@@ -846,7 +846,7 @@ int _sasl_conn_init(sasl_conn_t *conn,
 
   if(result != SASL_OK) MEMERROR( conn );
 
-  RETURN(conn, SASL_OK);
+  RETURN_VAL(conn, SASL_OK);
 }
 
 int _sasl_common_init(sasl_global_callbacks_t *global_callbacks)
@@ -1133,11 +1133,11 @@ int sasl_getprop(sasl_conn_t *conn, int propnum, const void **pvalue)
   } else if(result == SASL_NOTDONE) {
       sasl_seterror(conn, SASL_NOLOG,
 		    "Information that was requested is not yet available.");
-      RETURN(conn, result);
+      RETURN_VAL(conn, result);
   } else if(result != SASL_OK) {
       INTERROR(conn, result);
   } else
-      RETURN(conn, result); 
+      RETURN_VAL(conn, result);
 }
 
 /* set property in SASL connection state
@@ -1211,7 +1211,7 @@ int sasl_setprop(sasl_conn_t *conn, int propnum, const void *value)
       if(props->maxbufsize == 0 && props->min_ssf != 0) {
 	  sasl_seterror(conn, 0,
 			"Attempt to disable security layers (maxoutbuf == 0) with min_ssf > 0");
-	  RETURN(conn, SASL_TOOWEAK);
+	  RETURN_VAL(conn, SASL_TOOWEAK);
       }
 
       conn->props = *props;
@@ -1233,7 +1233,7 @@ int sasl_setprop(sasl_conn_t *conn, int propnum, const void *value)
       } else if (_sasl_ipfromstring(ipremoteport, NULL, 0)
 		 != SASL_OK) {
 	  sasl_seterror(conn, 0, "Bad IPREMOTEPORT value");
-	  RETURN(conn, SASL_BADPARAM);
+	  RETURN_VAL(conn, SASL_BADPARAM);
       } else {
 	  strcpy(conn->ipremoteport, ipremoteport);
 	  conn->got_ip_remote = 1;
@@ -1274,7 +1274,7 @@ int sasl_setprop(sasl_conn_t *conn, int propnum, const void *value)
       } else if (_sasl_ipfromstring(iplocalport, NULL, 0)
 		 != SASL_OK) {
 	  sasl_seterror(conn, 0, "Bad IPLOCALPORT value");
-	  RETURN(conn, SASL_BADPARAM);
+	  RETURN_VAL(conn, SASL_BADPARAM);
       } else {
 	  strcpy(conn->iplocalport, iplocalport);
 	  conn->got_ip_local = 1;
@@ -1367,7 +1367,7 @@ int sasl_setprop(sasl_conn_t *conn, int propnum, const void *value)
       result = SASL_BADPARAM;
   }
   
-  RETURN(conn, result);
+  RETURN_VAL(conn, result);
 }
 
 /* this is apparently no longer a user function */
@@ -1823,7 +1823,7 @@ _sasl_proxy_policy(sasl_conn_t *conn,
 	(memcmp(auth_identity, requested_user, rlen) != 0)) {
 	sasl_seterror(conn, 0,
 		      "Requested identity not authenticated identity");
-	RETURN(conn, SASL_BADAUTH);
+	RETURN_VAL(conn, SASL_BADAUTH);
     }
 
     return SASL_OK;
@@ -1924,7 +1924,7 @@ int _sasl_getcallback(sasl_conn_t * conn,
   *pproc = NULL;
   *pcontext = NULL;
   sasl_seterror(conn, SASL_NOLOG, "Unable to find a callback: %d", callbackid);
-  RETURN(conn,SASL_FAIL);
+  RETURN_VAL(conn,SASL_FAIL);
 }
 
 
@@ -2517,10 +2517,10 @@ int sasl_listmech(sasl_conn_t *conn,
     if(!conn) {
 	return SASL_BADPARAM;
     } else if(conn->type == SASL_CONN_SERVER) {
-	RETURN(conn, _sasl_server_listmech(conn, user, prefix, sep, suffix,
+	RETURN_VAL(conn, _sasl_server_listmech(conn, user, prefix, sep, suffix,
 					   result, plen, pcount));
     } else if (conn->type == SASL_CONN_CLIENT) {
-	RETURN(conn, _sasl_client_listmech(conn, prefix, sep, suffix,
+	RETURN_VAL(conn, _sasl_client_listmech(conn, prefix, sep, suffix,
 					   result, plen, pcount));
     }
     

--- a/lib/saslint.h
+++ b/lib/saslint.h
@@ -74,22 +74,22 @@
  *   memory errors.
  *  -Only errors (error codes < SASL_OK) should be remembered
  */
-#define RETURN(conn, val) { if(conn && (val) < SASL_OK) \
+#define RETURN_VAL(conn, val) { if(conn && (val) < SASL_OK) \
                                (conn)->error_code = (val); \
                             return (val); }
 #define MEMERROR(conn) {\
     if(conn) sasl_seterror( (conn), 0, \
                    "Out of Memory in " __FILE__ " near line %d", __LINE__ ); \
-    RETURN(conn, SASL_NOMEM) }
+    RETURN_VAL(conn, SASL_NOMEM) }
 #define PARAMERROR(conn) {\
     if(conn) sasl_seterror( (conn), SASL_NOLOG, \
                   "Parameter error in " __FILE__ " near line %d", __LINE__ ); \
-    RETURN(conn, SASL_BADPARAM) }
+    RETURN_VAL(conn, SASL_BADPARAM) }
 #define INTERROR(conn, val) {\
     if(conn) sasl_seterror( (conn), 0, \
                    "Internal Error %d in " __FILE__ " near line %d", (val),\
 		   __LINE__ ); \
-    RETURN(conn, (val)) }
+    RETURN_VAL(conn, (val)) }
 
 #ifndef PATH_MAX
 # ifdef WIN32

--- a/lib/server.c
+++ b/lib/server.c
@@ -155,7 +155,7 @@ int sasl_setpass(sasl_conn_t *conn,
 	 (current_mech == NULL) ) {
 	sasl_seterror( conn, SASL_NOLOG,
                   "No current SASL mechanism available");
-	RETURN(conn, SASL_BADPARAM);
+	RETURN_VAL(conn, SASL_BADPARAM);
     }
 
     /* Do we want to store SASL_AUX_PASSWORD_PROP (plain text)?  and
@@ -297,7 +297,7 @@ int sasl_setpass(sasl_conn_t *conn,
 	}
     }
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* local mechanism which disposes of server */
@@ -990,7 +990,7 @@ _sasl_transition(sasl_conn_t * conn,
 			      NULL, 0, SASL_SET_CREATE | flags);
     }
 
-    RETURN(conn,result);
+    RETURN_VAL(conn,result);
 }
 
 
@@ -1366,7 +1366,7 @@ static int do_authorization(sasl_server_conn_t *s_conn)
 		   (s_conn->user_realm ? (unsigned) strlen(s_conn->user_realm) : 0),
 		   s_conn->sparams->propctx);
 
-    RETURN(&s_conn->base, ret);
+    RETURN_VAL(&s_conn->base, ret);
 }
 
 
@@ -1483,7 +1483,7 @@ int sasl_server_start(sasl_conn_t *conn,
 
 	if (result != SASL_OK) {
 	    /* The library will eventually be freed, don't sweat it */
-	    RETURN(conn, result);
+	    RETURN_VAL(conn, result);
 	}
     }
 
@@ -1572,7 +1572,7 @@ int sasl_server_start(sasl_conn_t *conn,
 	conn->oparams.doneflag = 0;
     }
     
-    RETURN(conn,result);
+    RETURN_VAL(conn,result);
 }
 
 
@@ -1700,7 +1700,7 @@ int sasl_server_step(sasl_conn_t *conn,
 	conn->oparams.doneflag = 0;
     }
 
-    RETURN(conn, ret);
+    RETURN_VAL(conn, ret);
 }
 
 /* returns the length of all the mechanisms
@@ -1949,7 +1949,7 @@ static int _sasl_checkpass(sasl_conn_t *conn,
     if (result != SASL_OK)
 	sasl_seterror(conn, SASL_NOLOG, "checkpass failed");
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* check if a plaintext password is valid
@@ -1989,7 +1989,7 @@ int sasl_checkpass(sasl_conn_t *conn,
     result = _sasl_canon_user(conn, user, userlen,
 			      SASL_CU_AUTHID | SASL_CU_AUTHZID,
 			      &(conn->oparams));
-    if(result != SASL_OK) RETURN(conn, result);
+    if(result != SASL_OK) RETURN_VAL(conn, result);
     user = conn->oparams.user;
 
     /* Check the password and lookup additional properties */
@@ -2000,7 +2000,7 @@ int sasl_checkpass(sasl_conn_t *conn,
       result = do_authorization((sasl_server_conn_t *)conn);
     }
 
-    RETURN(conn,result);
+    RETURN_VAL(conn,result);
 }
 
 /* check if a user exists on server
@@ -2073,7 +2073,7 @@ int sasl_user_exists(sasl_conn_t *conn,
 	sasl_seterror(conn, SASL_NOLOG, "no plaintext password verifier?");
     }
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 }
 
 /* check if an apop exchange is valid
@@ -2135,7 +2135,7 @@ int sasl_checkapop(sasl_conn_t *conn,
     if (!user_end || strspn(user_end + 1, "0123456789abcdef") != 32) 
     {
         sasl_seterror(conn, 0, "Bad Digest");
-        RETURN(conn,SASL_BADPROT);
+        RETURN_VAL(conn,SASL_BADPROT);
     }
  
     user_len = (size_t)(user_end - response);
@@ -2147,7 +2147,7 @@ int sasl_checkapop(sasl_conn_t *conn,
     if(result != SASL_OK) 
     {
         sasl_FREE(user);
-        RETURN(conn, result);
+        RETURN_VAL(conn, result);
     }
 
     /* erase the plaintext password */
@@ -2162,7 +2162,7 @@ int sasl_checkapop(sasl_conn_t *conn,
 				      &(conn->oparams));
     sasl_FREE(user);
 
-    if(result != SASL_OK) RETURN(conn, result);
+    if(result != SASL_OK) RETURN_VAL(conn, result);
 
     /* Do APOP verification */
     result = _sasl_auxprop_verify_apop(conn, conn->oparams.authid,
@@ -2177,11 +2177,11 @@ int sasl_checkapop(sasl_conn_t *conn,
 	conn->oparams.authid = NULL;
     }
 
-    RETURN(conn, result);
+    RETURN_VAL(conn, result);
 #else /* sasl_checkapop was disabled at compile time */
     sasl_seterror(conn, SASL_NOLOG,
 	"sasl_checkapop called, but was disabled at compile time");
-    RETURN(conn, SASL_NOMECH);
+    RETURN_VAL(conn, SASL_NOMECH);
 #endif /* DO_SASL_CHECKAPOP */
 }
 

--- a/saslauthd/auth_sasldb.c
+++ b/saslauthd/auth_sasldb.c
@@ -51,9 +51,7 @@
 #include "../sasldb/sasldb.h"
 
 static int
-vf(void *context __attribute__((unused)),
-   char *file  __attribute__((unused)),
-   int type  __attribute__((unused)))
+vf(void)
 {
     /* always say ok */ 
     return SASL_OK;

--- a/saslauthd/saslauthd-main.c
+++ b/saslauthd/saslauthd-main.c
@@ -596,7 +596,7 @@ void signal_setup() {
 	/**************************************************************
 	 * Handler for SIGTERM
 	 **************************************************************/
-	act_sigterm.sa_handler = server_exit;
+	act_sigterm.sa_handler = handle_exit;
 	sigemptyset(&act_sigterm.sa_mask);
 
 	if (sigaction(SIGTERM, &act_sigterm, NULL) != 0) {
@@ -609,7 +609,7 @@ void signal_setup() {
 	/**************************************************************
 	 * Handler for SIGINT
 	 **************************************************************/
-	act_sigint.sa_handler = server_exit;
+	act_sigint.sa_handler = handle_exit;
 	sigemptyset(&act_sigint.sa_mask);
 
 	if (sigaction(SIGINT, &act_sigint, NULL) != 0) {
@@ -879,7 +879,7 @@ pid_t have_baby() {
 /*************************************************************
  * Reap in all the dead children
  **************************************************************/
-void handle_sigchld() {
+void handle_sigchld(__attribute__((unused)) int sig) {
 	pid_t pid;
 
 	while ((pid = waitpid(-1, 0, WNOHANG)) > 0) {
@@ -891,11 +891,15 @@ void handle_sigchld() {
 	return;
 }
 
+void handle_exit(__attribute__((unused)) int sig) {
+	server_exit();
+}
+
 
 /*************************************************************
  * Do some final cleanup here.
  **************************************************************/
-void server_exit() {
+void server_exit(void) {
 
 	/*********************************************************
 	 * If we're not the master process, don't do anything

--- a/saslauthd/saslauthd-main.h
+++ b/saslauthd/saslauthd-main.h
@@ -97,8 +97,9 @@ extern void	set_mech_option(const char *);
 extern void	set_run_path(const char *);
 extern void	signal_setup();
 extern void	detach_tty();
-extern void	handle_sigchld();
-extern void	server_exit();
+extern void	handle_sigchld(int sig);
+extern void	handle_exit(int sig);
+extern void	server_exit(void);
 extern pid_t	have_baby();
 
 /* ipc api delcarations */


### PR DESCRIPTION
Fedora 42 is going to use gcc 15 which changes some warnings into errors. Address the issues raised.

The issues addressed include:
- The RETURN macro is defined differently in two places. Rename one.
- Both atexit and the sigint and sigterm actions call server_exit(). The function arguments diff. Introduce a new generic signal handler to call server_exit() for sigint and sigterm signals.