### PR TITLE
Use HMAC-SHA256 for cache passwords over MD5

### DIFF
--- a/saslauthd/cache.h
+++ b/saslauthd/cache.h
@@ -92,7 +92,8 @@ struct lock_ctl {
 #define CACHE_MAX_BUCKETS_PER		6
 #define CACHE_MMAP_FILE			"/cache.mmap"  /* don't forget the "/" */
 #define CACHE_FLOCK_FILE		"/cache.flock" /* don't forget the "/" */
-
+/* HMAC key len must be less than or equal to the size of the hash function */
+#define CACHE_HMAC_DIGEST_LEN 32
 
 
 /* If debugging uncomment this for always verbose  */
@@ -130,7 +131,7 @@ struct bucket {
         unsigned int		user_offt;
         unsigned int		realm_offt;
         unsigned int		service_offt;
-        unsigned char   	pwd_digest[16];
+        unsigned char   	pwd_digest[CACHE_HMAC_DIGEST_LEN];
         time_t          	created;
 };
 


### PR DESCRIPTION
Currently the password cache uses MD5 for password caching in the mmapped cache file. This is not cryptographically secure.

This changes the algorithm to HMAC-SHA256. While other password verification algorithms are considered cryptographically superior (such as argon2id) in this case we want to maintain the cache's high performance, while improving the security of cached passwords.

To achieve this, the HMAC key itself is ephemeral and only ever stored in memory. This means that per invocation of saslauthd the HMAC key will be randomised. This results in the cache mmap file being effectively useless to an attacker who manages to steal the cache as they lack the HMAC key to attempt to validate or bruteforce any cached password.

This also means that if saslauthd crashes, the key material to access the cache is lost, effectively invalidating all records in that cache.

If an attacker were able to access the HMAC key in memory, then we can pretty safely assume that the attacker can also access plaintext password material making the need to access the key irrelevant.

As a result, this change improves security of cached passwords without a significant loss of performance in the cache's operation.