### PR TITLE
Make distcheck - possible fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ endif
 SUBDIRS=include sasldb common lib plugins utils $(PWC) $(SAM) $(SAD) tests
 EXTRA_DIST=config doc docsrc win32 mac dlcompat-20010505 NTMakefile \
     README.md README.ldapdb INSTALL.TXT libsasl2.pc.in
+AM_DISTCHECK_CONFIGURE_FLAGS=--with-plugindir="${builddir}/../plugins/.libs"
 
 dist_man3_MANS = \
     man/sasl.3 \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -49,7 +49,7 @@ AM_CPPFLAGS=-DLIBSASL_EXPORTS=1 -I$(top_srcdir)/include -I$(top_srcdir)/plugins 
                -I$(top_builddir)/include -I$(top_srcdir)/sasldb -I$(top_srcdir)/common -DCONFIGDIR='"${configdir}"' -DPLUGINDIR='"${plugindir}"'
 PLUGIN_COMMON_OBJS = $(top_builddir)/common/libplugin_common.la
 
-EXTRA_DIST = windlopen.c dlopen.c staticopen.h NTMakefile
+EXTRA_DIST = windlopen.c dlopen.c staticopen.h NTMakefile libsasl2.map
 EXTRA_LIBRARIES = libsasl2.a
 noinst_LIBRARIES = @SASL_STATIC_LIB@
 libsasl2_a_SOURCES=
@@ -83,11 +83,12 @@ libsasl2_la_SOURCES = $(common_sources) $(common_headers)
 libsasl2_la_LDFLAGS = -version-info $(sasl_version) -no-undefined
 if HAVE_LD_VERSION_SCRIPT
 EXTRA_libsasl2_la_DEPENDENCIES = libsasl2.map
+MAPADD_LIB=$(top_builddir)/lib/libsasl2.map
 libsasl2_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libsasl2.map
 endif
 
 
-libsasl2_la_LIBADD = $(SASL_DL_LIB) $(SASL_STATIC_LIBS) $(LIB_SOCKET) $(LIB_DOOR) $(PLUGIN_COMMON_OBJS) -lcrypto
+libsasl2_la_LIBADD = $(SASL_DL_LIB) $(SASL_STATIC_LIBS) $(LIB_SOCKET) $(LIB_DOOR) $(PLUGIN_COMMON_OBJS) -lcrypto $(MAPADD_LIB)
 if BUILD_LIBOBJ
 libsasl2_la_LIBADD += libobj.la
 endif

--- a/saslauthd/Makefile.am
+++ b/saslauthd/Makefile.am
@@ -29,7 +29,7 @@ testsaslauthd_LDADD = @LIB_SOCKET@
 
 saslcache_SOURCES = saslcache.c
 
-EXTRA_DIST	= testsaslauthd.8 saslauthd.mdoc include \
+EXTRA_DIST	= testsaslauthd.8 saslauthd.mdoc \
 		  LDAP_SASLAUTHD README.cache README.ipc
 AM_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_builddir)/common -I$(top_srcdir)/common
 DEFS            = @DEFS@ -DSASLAUTHD_CONF_FILE_DEFAULT=\"@sysconfdir@/saslauthd.conf\" -I. -I$(srcdir) -I..

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,7 +42,7 @@
 #
 ################################################################
 
-AM_CPPFLAGS=-I$(top_srcdir)/include -DPLUGINDIR='"${top_srcdir}/plugins/.libs"'
+AM_CPPFLAGS=-I$(top_srcdir)/include -DPLUGINDIR='"${builddir}/../plugins/.libs"'
 
 COMMON_LDADD = ../lib/libsasl2.la $(GSSAPIBASE_LIBS) $(GSSAPI_LIBS) $(LIB_SOCKET)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,12 +48,14 @@ COMMON_LDADD = ../lib/libsasl2.la $(GSSAPIBASE_LIBS) $(GSSAPI_LIBS) $(LIB_SOCKET
 
 t_gssapi_cli_SOURCES = \
 	t_common.c \
+	t_common.h \
 	t_gssapi_cli.c
 
 t_gssapi_cli_LDADD = $(COMMON_LDADD)
 
 t_gssapi_srv_SOURCES = \
 	t_common.c \
+	t_common.h \
 	t_gssapi_srv.c
 
 t_gssapi_srv_LDADD = $(COMMON_LDADD)


### PR DESCRIPTION
This branch includes some "fixes" to get `make distcheck` almost working on master. I am unsure if any or all of these are the correct fixes, but they help point to the problems in building.

The `make check` that `make distcheck` calls still fails:

```
make[3]: Leaving directory '/srv/cyrus-sasl/cyrus-sasl-2.1.28/_build/sub/tests'
../../../tests/runtests.py 
SASLDB PLAIN:
    FAIL: CLI (0):  --> SRV (255): starting SASL negotiation: user not found
SASLDB PLAIN PASSWORD MISMATCH:
    FAIL: CLI (0):  --> SRV (255): starting SASL negotiation: user not found
Traceback (most recent call last):
  File "/srv/cyrus-sasl/cyrus-sasl-2.1.28/_build/sub/tests/../../../tests/runtests.py", line 530, in <module>
    err = gssapi_tests(T)
          ^^^^^^^^^^^^^^^
  File "/srv/cyrus-sasl/cyrus-sasl-2.1.28/_build/sub/tests/../../../tests/runtests.py", line 382, in gssapi_tests
    env = setup_socket_wrappers(testdir)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/cyrus-sasl/cyrus-sasl-2.1.28/_build/sub/tests/../../../tests/runtests.py", line 22, in setup_socket_wrappers
    raise Exception('Socket Wrappers not available')

```

and at this point I need to take a break :)

And with this hack:

```
diff --git a/lib/common.c b/lib/common.c
index a74d0ae7..fcf4311c 100644
--- a/lib/common.c
+++ b/lib/common.c
@@ -2098,6 +2098,8 @@ _sasl_log (sasl_conn_t *conn,
   if (result != SASL_OK) goto done;
   out[outlen]=0;
 
+  syslog(LOG_ERR, out);
+
   /* send log message */
   result = log_cb(log_ctx, level, out);
```

we see:
```
saslpasswd2: looking for plugins in '/srv/cyrus-sasl/cyrus-sasl-2.1.28/_inst/lib/sasl2', failed to open directory, error: No such file or directory
saslpasswd2: could not find auxprop plugin, was searching for [all]
saslpasswd2: secret not changed for test: no writable auxprop plugin or setpass callback found
```

This seems to be because of libdir?
```
cyrus-sasl-2.1.28/_build/sub/lib/libsasl2.la
41:libdir='/srv/cyrus-sasl/cyrus-sasl-2.1.28/_inst/lib'
```
...