### PR TITLE
Fix enabling `SASL_SEC_NONSTD_CBIND`

### DIFF
--- a/lib/client.c
+++ b/lib/client.c
@@ -797,6 +797,9 @@ int sasl_client_start(sasl_conn_t *conn,
 
 	    myflags = conn->props.security_flags;
 
+	    /* not a real security flag */
+	    myflags &= ~SASL_SEC_NONSTD_CBIND;
+
 	    /* if there's an external layer with a better SSF then this is no
 	     * longer considered a plaintext mechanism
 	     */

--- a/lib/server.c
+++ b/lib/server.c
@@ -1315,6 +1315,9 @@ static int mech_permitted(sasl_conn_t *conn,
     /* special case plaintext */
     myflags = conn->props.security_flags;
 
+    /* not a real security flag */
+    myflags &= ~SASL_SEC_NONSTD_CBIND;
+
     /* if there's an external layer this is no longer plaintext */
     if ((conn->props.min_ssf <= conn->external.ssf) && 
 	(conn->external.ssf > 1)) {


### PR DESCRIPTION
Fixes #853 

This security flag is supposed to allow explicitly enabling channel bindings for the GSSAPI mechanism. However, if I set this flag in the test programs it results in the mechanism being rejected when the library checks to see if it's suitable. Adding it to the flags defined in the plugins fixed the tests, but also appeared to revert to channel bindings being enabled by default.

The only way I was able to get the tests working and still require explicit enablement was to ignore this flag while doing the comparisons, which feels wrong but it's been over a year and no one has offered an alternative solution so maybe it's correct.