### PR TITLE
saslauthd: fix checking for malformed HTTP responses

### DIFF
--- a/saslauthd/auth_httpform.c
+++ b/saslauthd/auth_httpform.c
@@ -370,19 +370,21 @@ static char *build_sasl_response(
     }
 
     /* isolate the HTTP response code and string */
-    http_response_code = strpbrk(http_response, SPACE) + 1;
+    http_response_code = strpbrk(http_response, SPACE);
     if (!http_response_code) {
 	logger(LOG_ERR, "auth_httpform", "invalid response to auth request: %s",
            http_response);
 	goto fail;
     }
+    http_response_code += 1;
 
-    http_response_string = strpbrk(http_response_code, SPACE) + 1;
+    http_response_string = strpbrk(http_response_code, SPACE);
     if (!http_response_string) {
 	logger(LOG_ERR, "auth_httpform", "invalid response to auth request: %s",
            http_response);
 	goto fail;
     }
+    http_response_string += 1;
 
     *(http_response_string-1) = '\0';  /* replace space after code with 0 */
 


### PR DESCRIPTION
The patch https://github.com/cyrusimap/cyrus-sasl/commit/cfb31560c4dca75c378b1dfd56c27b9d40eff2d0 doesn't work for issue #821. The checking for http_response_code and http_response_string should be before pointing to the next postion.