### PR TITLE
digestmd5: fix heap buffer overflow in add_to_challenge() when value needs escaping

### DIFF
--- a/plugins/digestmd5.c
+++ b/plugins/digestmd5.c
@@ -554,8 +554,10 @@ static int add_to_challenge(const sasl_utils_t *utils,
 	    if (quoted == NULL)
 		MEMERROR(utils);
 	    valuesize = strlen(quoted);
-	    /* As the quoted string is bigger, make sure we have enough
-	       space now */
+	    /* Recalculate newlen with the expanded (quoted) value size,
+	     * then reallocate. The initial newlen used the pre-quote
+	     * valuesize and is too small when escaping expands the string. */
+	    newlen = (unsigned) (*curlen + 1 + namesize + 2 + valuesize + 2);
 	    ret = _plug_buf_alloc(utils, str, buflen, newlen);
 	    if (ret == SASL_OK) {
 		strcat(*str, quoted);


### PR DESCRIPTION
## Summary

Fix a heap buffer overflow in `add_to_challenge()` in `plugins/digestmd5.c`.

Reported in issue #889 (CWE-122, CVSS 8.1 HIGH).

## Root cause

The buffer size `newlen` is computed from the **unquoted** `valuesize` before `quote()` is called:

```c
newlen = (unsigned) (*curlen + 1 + namesize + 2 + valuesize + 2);
ret = _plug_buf_alloc(utils, str, buflen, newlen);   // allocated with raw valuesize
```

When the value contains characters in `NEED_ESCAPING` (`\` or `"`), `quote()` doubles each one, producing a longer string. The existing code updates `valuesize = strlen(quoted)` but then calls `_plug_buf_alloc()` again with the **stale `newlen`** — so no reallocation happens. The `strcat(*str, quoted)` that follows writes past the end of the heap buffer.

## Fix

Recalculate `newlen` using the post-quote `valuesize` before calling `_plug_buf_alloc()`:

```c
valuesize = strlen(quoted);
// NEW: recalculate with expanded size
newlen = (unsigned) (*curlen + 1 + namesize + 2 + valuesize + 2);
ret = _plug_buf_alloc(utils, str, buflen, newlen);
```

## Impact

A malicious IMAP/SMTP/LDAP server can trigger this by sending a DIGEST-MD5 challenge with a `realm=` value containing many `\` or `"` characters. The overflow fires **client-side** during the initial challenge-response exchange, before any credentials are validated. Affected clients include OpenLDAP `ldapsearch`, Postfix, Cyrus IMAP `imtest`, ProFTPD, and any other application using Cyrus SASL for DIGEST-MD5.

ASAN confirms: heap-buffer-overflow WRITE of 10–12 bytes past a 68-byte allocation (from fuzzing, 35 unique crash inputs reported in #889).

## References

- Fixes #889