### PR TITLE
checkpw: fix format string injection via pwcheck daemon response

### DIFF
--- a/lib/checkpw.c
+++ b/lib/checkpw.c
@@ -562,7 +562,7 @@ static int pwcheck_verify_password(sasl_conn_t *conn,
     }
 
     response[start] = '\0';
-    sasl_seterror(conn,0,response);
+    sasl_seterror(conn, 0, "%s", response);
     return SASL_BADAUTH;
 }
 


### PR DESCRIPTION
## Summary

Fix a format string injection vulnerability in `pwcheck_verify_password()` in `lib/checkpw.c`.

Reported in issue #889 (CWE-134, CVSS 5.3 MEDIUM).

## Root cause

The function reads the pwcheck daemon's response from a Unix socket and passes it directly as the format string argument to `sasl_seterror()`:

```c
response[start] = '\0';
sasl_seterror(conn, 0, response);   // BUG: response used as format string
```

`sasl_seterror()` implements a custom printf-style parser that handles only `%s`, `%m`, `%z`, `%c`, `%d`, `%i`. When the response contains an unsupported specifier like `%.*s`, the parser's `default` branch accumulates `.` and `*` without consuming any varargs, then the `s` branch calls `va_arg(ap, char*)` — receiving the precision integer (e.g. `4`) as a pointer. This gets passed to `_sasl_add_string()` → `strlen()`, causing SIGSEGV.

## Fix

One character change — pass `response` as a `%s` argument:

```c
sasl_seterror(conn, 0, "%s", response);
```

## Impact

An attacker controlling the pwcheck daemon's response (e.g. by replacing the Unix socket via a local privilege escalation, or by compromising the pwcheck process) can crash any SASL-dependent service configured with `pwcheck_method: pwcheck` (Cyrus IMAP, Postfix, OpenLDAP slapd, Sendmail, ProFTPD).

15 unique crash inputs confirmed via fuzzing (#889).

## References

- Fixes #889