### PR TITLE
auxprop: fix NULL pointer dereference in prop_dup()

### DIFF
--- a/lib/auxprop.c
+++ b/lib/auxprop.c
@@ -191,6 +191,7 @@ int prop_dup(struct propctx *src_ctx, struct propctx **dst_ctx)
 
     /* Now dup the values */
     for(i=0; i<src_ctx->used_values; i++) {
+	if(!src_ctx->values[i].name) continue;
 	retval->values[i].name = src_ctx->values[i].name;
 	result = prop_setvals(retval, retval->values[i].name,
 			      src_ctx->values[i].values);


### PR DESCRIPTION
## Summary

Fix a NULL pointer dereference in `prop_dup()` in `lib/auxprop.c`.

Reported in issue #889 (CWE-476, CVSS 5.3 MEDIUM).

## Root cause

`prop_dup()` iterates over `src_ctx->used_values` entries and copies each to the destination context:

```c
for(i=0; i<src_ctx->used_values; i++) {
    retval->values[i].name = src_ctx->values[i].name;
    result = prop_setvals(retval, retval->values[i].name,   // crashes if name is NULL
                          src_ctx->values[i].values);
```

After certain sequences of `prop_set()` / `prop_clear()` calls, `used_values` can become inconsistent with the actual contents of the `values` array, leaving `values[i].name == NULL` for some entries. `prop_setvals()` → `prop_set()` calls `strlen(name)`, which crashes with SIGSEGV on a NULL pointer.

## Fix

Skip entries with a NULL name in the dup loop:

```c
for(i=0; i<src_ctx->used_values; i++) {
    if(!src_ctx->values[i].name) continue;   // NEW
    retval->values[i].name = src_ctx->values[i].name;
```

## Impact

Any SASL-dependent service that processes authentication requests through the auxprop path (Postfix, Cyrus IMAP, OpenLDAP slapd, Sendmail, ProFTPD) can be crashed by an unauthenticated remote attacker. The crash fires before credentials are validated. 16 unique crash inputs confirmed via fuzzing (#889).

## References

- Fixes #889